### PR TITLE
Parse tags in Markdown documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### Added
+
+* Support for tags.
+    * Many tag flavors are supported: `#hashtags`, `:colon:separated:tags:` and even Bear's [`#multi-word tags#`](https://blog.bear.app/2017/11/bear-tips-how-to-create-multi-word-tags/). If you prefer to use a YAML frontmatter, list your tags with the keys `tags` or `keywords`.

--- a/adapter/markdown/extensions/tag.go
+++ b/adapter/markdown/extensions/tag.go
@@ -1,0 +1,130 @@
+package extensions
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	gast "github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// Tags represents a list of inline tags in a Markdown document.
+type Tags struct {
+	gast.BaseInline
+	// Tags in this list.
+	Tags []string
+}
+
+func (n *Tags) Dump(source []byte, level int) {
+	m := map[string]string{}
+	m["Tags"] = strings.Join(n.Tags, ", ")
+	gast.DumpHelper(n, source, level, m, nil)
+}
+
+// KindTags is a NodeKind of the Tags node.
+var KindTags = gast.NewNodeKind("Tags")
+
+func (n *Tags) Kind() gast.NodeKind {
+	return KindTags
+}
+
+// TagExt is an extension parsing various flavors of tags.
+//
+// * #hashtags, including Bear's #multi words# tags
+// * :colon:separated:tags:`, e.g. vimwiki and Org mode
+//
+// Are authorized in a tag:
+// * unicode categories [L]etter and [N]umber
+// * / @ ' ~ - _ $ % & + = and when possible # :
+// * any character escaped with \, including whitespace
+var TagExt = &tagExt{}
+
+type tagExt struct{}
+
+func (t *tagExt) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(
+		parser.WithInlineParsers(
+			util.Prioritized(&hashtagParser{}, 2000),
+			util.Prioritized(&colontagParser{}, 2000),
+		),
+	)
+}
+
+// hashtagParser parses #hashtags, including Bear's #multi words# tags
+type hashtagParser struct{}
+
+func (p *hashtagParser) Trigger() []byte {
+	return []byte{'#'}
+}
+
+func (p *hashtagParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	line, _ := block.PeekLine()
+
+	var (
+		tag string
+	)
+
+	var (
+		escaping = false // Found a backslash, next character will be literal
+		endPos   = 0     // Last position of the link in the line
+	)
+
+	for i, char := range string(line[1:]) {
+		endPos = i
+
+		if char == '\\' {
+			escaping = true
+			continue
+		}
+
+		if !escaping && !isValidTagChar(char, '#') {
+			break
+		}
+		tag += string(char)
+
+		escaping = false
+	}
+
+	if len(tag) == 0 || !isValidHashTag(tag) {
+		return nil
+	}
+
+	block.Advance(endPos)
+
+	return &Tags{
+		BaseInline: gast.BaseInline{},
+		Tags:       []string{tag},
+	}
+}
+
+// colontagParser parses :colon:separated:tags:.
+type colontagParser struct{}
+
+func (p *colontagParser) Trigger() []byte {
+	return []byte{':'}
+}
+
+func (p *colontagParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	return nil
+}
+
+func isValidTagChar(r rune, excluded rune) bool {
+	return r != excluded && (unicode.IsLetter(r) || unicode.IsNumber(r) ||
+		r == '/' || r == '@' || r == '\'' || r == '~' ||
+		r == '-' || r == '_' || r == '$' || r == '%' ||
+		r == '&' || r == '+' || r == '=' || r == ':' ||
+		r == '#')
+}
+
+func isValidHashTag(tag string) bool {
+	for _, char := range tag {
+		if !unicode.IsNumber(char) {
+			return true
+		}
+	}
+	return false
+}

--- a/adapter/markdown/extensions/wikilink.go
+++ b/adapter/markdown/extensions/wikilink.go
@@ -11,10 +11,10 @@ import (
 	"github.com/yuin/goldmark/util"
 )
 
-// WikiLink is an extension parsing wiki links and Neuron's Folgezettel.
+// WikiLinkExt is an extension parsing wiki links and Neuron's Folgezettel.
 //
 // For example, [[wiki link]], [[[legacy downlink]]], #[[uplink]], [[downlink]]#.
-var WikiLink = &wikiLink{}
+var WikiLinkExt = &wikiLink{}
 
 type wikiLink struct{}
 

--- a/adapter/markdown/markdown.go
+++ b/adapter/markdown/markdown.go
@@ -24,7 +24,7 @@ type Parser struct {
 }
 
 type ParserOpts struct {
-	// Indicates whether Bear's word tags should be parsed.
+	// Indicates whether Bear's word tags are parsed.
 	WordTagEnabled bool
 }
 

--- a/adapter/markdown/markdown.go
+++ b/adapter/markdown/markdown.go
@@ -24,8 +24,12 @@ type Parser struct {
 }
 
 type ParserOpts struct {
-	// Indicates whether Bear's word tags are parsed.
+	// Indicates whether #hashtags are parsed.
+	HashtagEnabled bool
+	// Indicates whether Bear's word tags are parsed. Hashtags must be enabled as well.
 	WordTagEnabled bool
+	// Indicates whether :colon:tags: are parsed.
+	ColontagEnabled bool
 }
 
 // NewParser creates a new Markdown Parser.
@@ -45,7 +49,9 @@ func NewParser(options ParserOpts) *Parser {
 				),
 				extensions.WikiLinkExt,
 				&extensions.TagExt{
-					WordTagEnabled: options.WordTagEnabled,
+					HashtagEnabled:  options.HashtagEnabled,
+					WordTagEnabled:  options.WordTagEnabled,
+					ColontagEnabled: options.ColontagEnabled,
 				},
 			),
 		),

--- a/adapter/markdown/markdown.go
+++ b/adapter/markdown/markdown.go
@@ -189,7 +189,7 @@ func parseTags(frontmatter frontmatter, root ast.Node, source []byte) ([]string,
 		return ast.WalkContinue, nil
 	})
 
-	return tags, err
+	return strutil.RemoveDuplicates(tags), err
 }
 
 // parseLinks extracts outbound links from the note.

--- a/adapter/markdown/markdown.go
+++ b/adapter/markdown/markdown.go
@@ -27,8 +27,8 @@ type Parser struct {
 type ParserOpts struct {
 	// Indicates whether #hashtags are parsed.
 	HashtagEnabled bool
-	// Indicates whether Bear's word tags are parsed. Hashtags must be enabled as well.
-	WordTagEnabled bool
+	// Indicates whether Bear's multi-word tags are parsed. Hashtags must be enabled as well.
+	MultiWordTagEnabled bool
 	// Indicates whether :colon:tags: are parsed.
 	ColontagEnabled bool
 }
@@ -50,9 +50,9 @@ func NewParser(options ParserOpts) *Parser {
 				),
 				extensions.WikiLinkExt,
 				&extensions.TagExt{
-					HashtagEnabled:  options.HashtagEnabled,
-					WordTagEnabled:  options.WordTagEnabled,
-					ColontagEnabled: options.ColontagEnabled,
+					HashtagEnabled:      options.HashtagEnabled,
+					MultiWordTagEnabled: options.MultiWordTagEnabled,
+					ColontagEnabled:     options.ColontagEnabled,
 				},
 			),
 		),

--- a/adapter/markdown/markdown.go
+++ b/adapter/markdown/markdown.go
@@ -175,7 +175,10 @@ func parseTags(frontmatter frontmatter, root ast.Node, source []byte) ([]string,
 
 	for _, key := range []string{"tag", "tags", "keyword", "keywords"} {
 		for _, t := range findFMTags(key) {
-			tags = append(tags, t)
+			// Trims any # prefix to support hashtags embedded in YAML
+			// frontmatter, as in Simple Markdown Zettelkasten:
+			// http://evantravers.com/articles/2020/11/23/zettelkasten-updates/
+			tags = append(tags, strings.TrimPrefix(t, "#"))
 		}
 	}
 

--- a/adapter/markdown/markdown.go
+++ b/adapter/markdown/markdown.go
@@ -23,8 +23,13 @@ type Parser struct {
 	md goldmark.Markdown
 }
 
+type ParserOpts struct {
+	// Indicates whether Bear's word tags should be parsed.
+	WordTagEnabled bool
+}
+
 // NewParser creates a new Markdown Parser.
-func NewParser() *Parser {
+func NewParser(options ParserOpts) *Parser {
 	return &Parser{
 		md: goldmark.New(
 			goldmark.WithExtensions(
@@ -39,7 +44,9 @@ func NewParser() *Parser {
 					),
 				),
 				extensions.WikiLinkExt,
-				extensions.TagExt,
+				&extensions.TagExt{
+					WordTagEnabled: options.WordTagEnabled,
+				},
 			),
 		),
 	}

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -285,6 +285,48 @@ func TestParseMixedTags(t *testing.T) {
 	test(":#colontag: #:tag: #:word:tag:#", []string{"#colontag", ":tag:", ":word:tag:"})
 }
 
+func TestParseTagsFromFrontmatter(t *testing.T) {
+	test := func(source string, tags []string) {
+		content := parse(t, source)
+		assert.Equal(t, content.Tags, tags)
+	}
+
+	test(`---
+Tags:
+    - tag1
+    - tag 2
+---
+
+Body
+`, []string{"tag1", "tag 2"})
+
+	test(`---
+Keywords: [keyword1, keyword 2]
+---
+
+Body
+`, []string{"keyword1", "keyword 2"})
+
+	test(`---
+tags: [tag1, tag 2]
+keywords:
+    - keyword1
+    - keyword 2
+---
+
+Body
+`, []string{"tag1", "tag 2", "keyword1", "keyword 2"})
+
+	// When a string, parse space-separated tags.
+	test(`---
+Tags: "tag1 #tag-2"
+Keywords: kw1 kw2 kw3
+---
+
+Body
+`, []string{"tag1", "#tag-2", "kw1", "kw2", "kw3"})
+}
+
 func TestParseLinks(t *testing.T) {
 	test := func(source string, links []note.Link) {
 		content := parse(t, source)

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -180,9 +180,9 @@ func TestParseHashtags(t *testing.T) {
 	test("#a/@'~-_$%&+=: end", []string{"a/@'~-_$%&+=:"})
 	// Escape punctuation and space
 	test(`#an\ \\espaced\ tag\!`, []string{`an \espaced tag!`})
-	// Hashtag containing only numbers and dots are invalid
+	// Hashtags containing only numbers and dots are invalid
 	test("#123, #1.2.3", []string{})
-	// Must not be preceded by a hash or any other valid hashtag character.
+	// Must not be preceded by a hash or any other valid hashtag character
 	test("##invalid also#invalid", []string{})
 	// Bear's multi word tags are disabled
 	test("#multi word# end", []string{"multi"})
@@ -215,9 +215,9 @@ func TestParseWordtags(t *testing.T) {
 	test("#a/@'~-_$%&+=: end", []string{"a/@'~-_$%&+=:"})
 	// Escape punctuation and space
 	test(`#an\ \\espaced\ tag\!`, []string{`an \espaced tag!`})
-	// Hashtag containing only numbers and dots are invalid
+	// Hashtags containing only numbers and dots are invalid
 	test("#123, #1.2.3", []string{})
-	// Must not be preceded by a hash or any other valid hashtag character.
+	// Must not be preceded by a hash or any other valid hashtag character
 	test("##invalid also#invalid", []string{})
 	// Bear's multi word tags
 	test("#multi word#", []string{"multi word"})
@@ -229,6 +229,44 @@ func TestParseWordtags(t *testing.T) {
 	test("a #multi word# in the middle", []string{"multi word"})
 	test("a #multi word#, and a #tag", []string{"multi word", "tag"})
 	test("#multi, word#", []string{"multi"})
+}
+
+func TestParseColontags(t *testing.T) {
+	test := func(source string, tags []string) {
+		content := parseWithOptions(t, source, ParserOpts{})
+		assert.Equal(t, content.Tags, tags)
+	}
+
+	test("", []string{})
+	test(":", []string{})
+	test("::", []string{})
+	test("not:valid:", []string{})
+	test(":no tags:", []string{})
+	test(": no-tags:", []string{})
+	test(":no-tags :", []string{})
+	test(":single-colontag:", []string{"single-colontag"})
+	test("a :tag: in the middle", []string{"tag"})
+	test(":multiple:colontags:", []string{"multiple", "colontags"})
+	test(":multiple::colontags:", []string{"multiple"})
+	test(":multiple: :colontags:", []string{"multiple", "colontags"})
+	test(":multiple:,:colontags:", []string{"multiple", "colontags"})
+	test(":more:than:two:colontags:", []string{"more", "than", "two", "colontags"})
+	test(":multiple :colontags", []string{})
+	test(":multiple :colontags:", []string{"colontags"})
+	// Unicode colontags
+	test(":libellé-français:日本語ハッシュタグ:", []string{"libellé-français", "日本語ハッシュタグ"})
+	// Punctuation is not allowed
+	test(":a : :b,: :c;: :d.: :e!: :f?: :g*: :h\": :i(: :j): :k[: :l]: :m{: :n}:", []string{})
+	// Authorized special characters
+	test(":#a/@'~-_$%&+=: end", []string{"#a/@'~-_$%&+="})
+	// Escape punctuation and space
+	test(`:an\ \\espaced\ tag\!:`, []string{`an \espaced tag!`})
+	// A colontag containing only numbers is valid
+	test(":123:1.2.3:", []string{"123"})
+	// Must not be preceded by a hash or any other valid colontag character
+	test("##invalid also#invalid", []string{})
+	// Bear's multi word tags are disabled
+	test("#multi word# end", []string{"multi"})
 }
 
 func TestParseLinks(t *testing.T) {

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -271,6 +271,20 @@ func TestParseColontags(t *testing.T) {
 	test("::invalid also:invalid:", []string{})
 }
 
+func TestParseMixedTags(t *testing.T) {
+	test := func(source string, tags []string) {
+		content := parseWithOptions(t, source, ParserOpts{
+			HashtagEnabled:  true,
+			WordTagEnabled:  true,
+			ColontagEnabled: true,
+		})
+		assert.Equal(t, content.Tags, tags)
+	}
+
+	test(":colontag: #tag #word tag#", []string{"colontag", "tag", "word tag"})
+	test(":#colontag: #:tag: #:word:tag:#", []string{"#colontag", ":tag:", ":word:tag:"})
+}
+
 func TestParseLinks(t *testing.T) {
 	test := func(source string, links []note.Link) {
 		content := parse(t, source)
@@ -429,7 +443,11 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 }
 
 func parse(t *testing.T, source string) note.Content {
-	return parseWithOptions(t, source, ParserOpts{})
+	return parseWithOptions(t, source, ParserOpts{
+		HashtagEnabled:  true,
+		WordTagEnabled:  true,
+		ColontagEnabled: true,
+	})
 }
 
 func parseWithOptions(t *testing.T, source string, options ParserOpts) note.Content {

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -293,7 +293,7 @@ func TestParseTagsFromFrontmatter(t *testing.T) {
 
 	test(`---
 Tags:
-    - tag1
+    - "#tag1"
     - tag 2
 ---
 
@@ -301,7 +301,7 @@ Body
 `, []string{"tag1", "tag 2"})
 
 	test(`---
-Keywords: [keyword1, keyword 2]
+Keywords: [keyword1, "#keyword 2"]
 ---
 
 Body
@@ -324,7 +324,7 @@ Keywords: kw1 kw2 kw3
 ---
 
 Body
-`, []string{"tag1", "#tag-2", "kw1", "kw2", "kw3"})
+`, []string{"tag1", "tag-2", "kw1", "kw2", "kw3"})
 }
 
 func TestParseTagsIgnoresDuplicates(t *testing.T) {
@@ -334,7 +334,7 @@ func TestParseTagsIgnoresDuplicates(t *testing.T) {
 	}
 
 	test(`---
-Tags: [tag1, tag1, tag2]
+Tags: [tag1, "#tag1", tag2]
 ---
 
 #tag1 #tag2 #tag3 #tag3 :tag2:

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -156,6 +156,7 @@ Paragraph`,
 func TestParseHashtags(t *testing.T) {
 	test := func(source string, tags []string) {
 		content := parseWithOptions(t, source, ParserOpts{
+			HashtagEnabled: true,
 			WordTagEnabled: false,
 		})
 		assert.Equal(t, content.Tags, tags)
@@ -191,6 +192,7 @@ func TestParseHashtags(t *testing.T) {
 func TestParseWordtags(t *testing.T) {
 	test := func(source string, tags []string) {
 		content := parseWithOptions(t, source, ParserOpts{
+			HashtagEnabled: true,
 			WordTagEnabled: true,
 		})
 		assert.Equal(t, content.Tags, tags)
@@ -233,7 +235,9 @@ func TestParseWordtags(t *testing.T) {
 
 func TestParseColontags(t *testing.T) {
 	test := func(source string, tags []string) {
-		content := parseWithOptions(t, source, ParserOpts{})
+		content := parseWithOptions(t, source, ParserOpts{
+			ColontagEnabled: true,
+		})
 		assert.Equal(t, content.Tags, tags)
 	}
 
@@ -263,10 +267,8 @@ func TestParseColontags(t *testing.T) {
 	test(`:an\ \\espaced\ tag\!:`, []string{`an \espaced tag!`})
 	// A colontag containing only numbers is valid
 	test(":123:1.2.3:", []string{"123"})
-	// Must not be preceded by a hash or any other valid colontag character
-	test("##invalid also#invalid", []string{})
-	// Bear's multi word tags are disabled
-	test("#multi word# end", []string{"multi"})
+	// Must not be preceded by a : or any other valid colontag character
+	test("::invalid also:invalid:", []string{})
 }
 
 func TestParseLinks(t *testing.T) {

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -153,6 +153,32 @@ Paragraph`,
 	)
 }
 
+func TestParseTags(t *testing.T) {
+	test := func(source string, tags []string) {
+		content := parse(t, source)
+		assert.Equal(t, content.Tags, tags)
+	}
+
+	test("", []string{})
+	test("# No tags around here", []string{})
+	test("#single-hashtag", []string{"single-hashtag"})
+	test("a #tag in the middle", []string{"tag"})
+	test("#multiple #hashtags", []string{"multiple", "hashtags"})
+	// Unicode hashtags
+	test("#libellé-français, #日本語ハッシュタグ", []string{"libellé-français", "日本語ハッシュタグ"})
+	// Punctuation breaking tags
+	test(
+		"#a #b, #c; #d. #e! #f? #g* #h\", #i(, #j), #k[, #l], #m{, #n}",
+		[]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n"},
+	)
+	// Authorized special characters
+	test("#a/@'~-_$%&+=: end", []string{"a/@'~-_$%&+=:"})
+	// Escape punctuation and space
+	test(`#an\ espaced\ tag\!`, []string{"an espaced tag!"})
+	// Hashtag containing only numbers are invalid
+	test("#123, #1.2.3", []string{})
+}
+
 func TestParseLinks(t *testing.T) {
 	test := func(source string, links []note.Link) {
 		content := parse(t, source)

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -327,6 +327,20 @@ Body
 `, []string{"tag1", "#tag-2", "kw1", "kw2", "kw3"})
 }
 
+func TestParseTagsIgnoresDuplicates(t *testing.T) {
+	test := func(source string, tags []string) {
+		content := parse(t, source)
+		assert.Equal(t, content.Tags, tags)
+	}
+
+	test(`---
+Tags: [tag1, tag1, tag2]
+---
+
+#tag1 #tag2 #tag3 #tag3 :tag2:
+`, []string{"tag1", "tag2", "tag3"})
+}
+
 func TestParseLinks(t *testing.T) {
 	test := func(source string, links []note.Link) {
 		content := parse(t, source)

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -156,8 +156,8 @@ Paragraph`,
 func TestParseHashtags(t *testing.T) {
 	test := func(source string, tags []string) {
 		content := parseWithOptions(t, source, ParserOpts{
-			HashtagEnabled: true,
-			WordTagEnabled: false,
+			HashtagEnabled:      true,
+			MultiWordTagEnabled: false,
 		})
 		assert.Equal(t, content.Tags, tags)
 	}
@@ -185,15 +185,15 @@ func TestParseHashtags(t *testing.T) {
 	test("#123, #1.2.3", []string{})
 	// Must not be preceded by a hash or any other valid hashtag character
 	test("##invalid also#invalid", []string{})
-	// Bear's multi word tags are disabled
+	// Bear's multi multi-word tags are disabled
 	test("#multi word# end", []string{"multi"})
 }
 
 func TestParseWordtags(t *testing.T) {
 	test := func(source string, tags []string) {
 		content := parseWithOptions(t, source, ParserOpts{
-			HashtagEnabled: true,
-			WordTagEnabled: true,
+			HashtagEnabled:      true,
+			MultiWordTagEnabled: true,
 		})
 		assert.Equal(t, content.Tags, tags)
 	}
@@ -221,7 +221,7 @@ func TestParseWordtags(t *testing.T) {
 	test("#123, #1.2.3", []string{})
 	// Must not be preceded by a hash or any other valid hashtag character
 	test("##invalid also#invalid", []string{})
-	// Bear's multi word tags
+	// Bear's multi multi-word tags
 	test("#multi word#", []string{"multi word"})
 	test("#surrounded# end", []string{"surrounded"})
 	test("#multi word#end", []string{"multi word"})
@@ -274,9 +274,9 @@ func TestParseColontags(t *testing.T) {
 func TestParseMixedTags(t *testing.T) {
 	test := func(source string, tags []string) {
 		content := parseWithOptions(t, source, ParserOpts{
-			HashtagEnabled:  true,
-			WordTagEnabled:  true,
-			ColontagEnabled: true,
+			HashtagEnabled:      true,
+			MultiWordTagEnabled: true,
+			ColontagEnabled:     true,
 		})
 		assert.Equal(t, content.Tags, tags)
 	}
@@ -500,9 +500,9 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 
 func parse(t *testing.T, source string) note.Content {
 	return parseWithOptions(t, source, ParserOpts{
-		HashtagEnabled:  true,
-		WordTagEnabled:  true,
-		ColontagEnabled: true,
+		HashtagEnabled:      true,
+		MultiWordTagEnabled: true,
+		ColontagEnabled:     true,
 	})
 }
 

--- a/adapter/markdown/markdown_test.go
+++ b/adapter/markdown/markdown_test.go
@@ -160,10 +160,13 @@ func TestParseTags(t *testing.T) {
 	}
 
 	test("", []string{})
+	test("#", []string{})
+	test("##", []string{})
 	test("# No tags around here", []string{})
 	test("#single-hashtag", []string{"single-hashtag"})
 	test("a #tag in the middle", []string{"tag"})
 	test("#multiple #hashtags", []string{"multiple", "hashtags"})
+	test("#multiple#hashtags", []string{})
 	// Unicode hashtags
 	test("#libellé-français, #日本語ハッシュタグ", []string{"libellé-français", "日本語ハッシュタグ"})
 	// Punctuation breaking tags
@@ -174,9 +177,21 @@ func TestParseTags(t *testing.T) {
 	// Authorized special characters
 	test("#a/@'~-_$%&+=: end", []string{"a/@'~-_$%&+=:"})
 	// Escape punctuation and space
-	test(`#an\ espaced\ tag\!`, []string{"an espaced tag!"})
-	// Hashtag containing only numbers are invalid
+	test(`#an\ \\espaced\ tag\!`, []string{`an \espaced tag!`})
+	// Hashtag containing only numbers and dots are invalid
 	test("#123, #1.2.3", []string{})
+	// Must not be preceded by a hash or any other valid hashtag character.
+	test("##invalid also#invalid", []string{})
+	// Bear's multi word tags
+	test("#multi word#", []string{"multi word"})
+	test("#surrounded# end", []string{})
+	test("#multi word#end", []string{"multi word"})
+	test("#multi word #other", []string{"multi", "other"})
+	test("#multi word# #other", []string{"multi word", "other"})
+	test("#multi word##other", []string{"multi word"})
+	test("a #multi word# in the middle", []string{"multi word"})
+	test("a #multi word#, and a #tag", []string{"multi word", "tag"})
+	test("#multi, word#", []string{"multi"})
 }
 
 func TestParseLinks(t *testing.T) {

--- a/adapter/sqlite/collection_dao.go
+++ b/adapter/sqlite/collection_dao.go
@@ -1,0 +1,187 @@
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/mickael-menu/zk/core"
+	"github.com/mickael-menu/zk/util"
+	"github.com/mickael-menu/zk/util/errors"
+)
+
+// CollectionDAO persists collections (e.g. tags) in the SQLite database.
+type CollectionDAO struct {
+	tx     Transaction
+	logger util.Logger
+
+	// Prepared SQL statements
+	createCollectionStmt   *LazyStmt
+	findCollectionStmt     *LazyStmt
+	findAssociationStmt    *LazyStmt
+	createAssociationStmt  *LazyStmt
+	removeAssociationsStmt *LazyStmt
+}
+
+// NewCollectionDAO creates a new instance of a DAO working on the given
+// database transaction.
+func NewCollectionDAO(tx Transaction, logger util.Logger) *CollectionDAO {
+	return &CollectionDAO{
+		tx:     tx,
+		logger: logger,
+
+		// Create a new collection.
+		createCollectionStmt: tx.PrepareLazy(`
+			INSERT INTO collections (kind, name)
+			VALUES (?, ?)
+		`),
+
+		// Finds a collection's ID from its kind and name.
+		findCollectionStmt: tx.PrepareLazy(`
+			SELECT id FROM collections
+			 WHERE kind = ? AND name = ?
+		`),
+
+		// Returns whether a note and a collection are associated.
+		findAssociationStmt: tx.PrepareLazy(`
+			SELECT id FROM notes_collections
+			 WHERE note_id = ? AND collection_id = ?
+		`),
+
+		// Creates a new association between a note and a collection.
+		createAssociationStmt: tx.PrepareLazy(`
+			INSERT INTO notes_collections (note_id, collection_id)
+			VALUES (?, ?)
+		`),
+
+		// Removes all associations for the given note.
+		removeAssociationsStmt: tx.PrepareLazy(`
+			DELETE FROM notes_collections
+			 WHERE note_id = ?
+		`),
+	}
+}
+
+// FindOrCreate returns the ID of the collection with given kind and name.
+// Creates the collection if it does not already exist.
+func (d *CollectionDAO) FindOrCreate(kind string, name string) (core.CollectionId, error) {
+	id, err := d.findCollection(kind, name)
+
+	switch {
+	case err != nil:
+		return id, err
+	case id.IsValid():
+		return id, nil
+	default:
+		return d.create(kind, name)
+	}
+}
+
+func (d *CollectionDAO) findCollection(kind string, name string) (core.CollectionId, error) {
+	wrap := errors.Wrapperf("failed to get %s named %s", kind, name)
+
+	row, err := d.findCollectionStmt.QueryRow(kind, name)
+	if err != nil {
+		return core.CollectionId(0), wrap(err)
+	}
+
+	var id sql.NullInt64
+	err = row.Scan(&id)
+
+	switch {
+	case err == sql.ErrNoRows:
+		return core.CollectionId(0), nil
+	case err != nil:
+		return core.CollectionId(0), wrap(err)
+	default:
+		return core.CollectionId(id.Int64), nil
+	}
+}
+
+func (d *CollectionDAO) create(kind string, name string) (core.CollectionId, error) {
+	wrap := errors.Wrapperf("failed to create new %s named %s", kind, name)
+
+	res, err := d.createCollectionStmt.Exec(kind, name)
+	if err != nil {
+		return 0, wrap(err)
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, wrap(err)
+	}
+
+	return core.CollectionId(id), nil
+}
+
+// Associate creates a new association between a note and a collection, if it
+// does not already exist.
+func (d *CollectionDAO) Associate(noteId core.NoteId, collectionId core.CollectionId) (core.NoteCollectionId, error) {
+	wrap := errors.Wrapperf("failed to associate note %d to collection %d", noteId, collectionId)
+
+	id, err := d.findAssociation(noteId, collectionId)
+
+	switch {
+	case err != nil:
+		return id, wrap(err)
+	case id.IsValid():
+		return id, nil
+	default:
+		id, err = d.createAssociation(noteId, collectionId)
+		return id, wrap(err)
+	}
+}
+
+func (d *CollectionDAO) findAssociation(noteId core.NoteId, collectionId core.CollectionId) (core.NoteCollectionId, error) {
+	if !noteId.IsValid() || !collectionId.IsValid() {
+		return 0, fmt.Errorf("Note ID (%d) or collection ID (%d) not valid", noteId, collectionId)
+	}
+
+	row, err := d.findAssociationStmt.QueryRow(noteId, collectionId)
+	if err != nil {
+		return 0, err
+	}
+
+	var id sql.NullInt64
+	err = row.Scan(&id)
+
+	switch {
+	case err == sql.ErrNoRows:
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return core.NoteCollectionId(id.Int64), nil
+	}
+}
+
+func (d *CollectionDAO) createAssociation(noteId core.NoteId, collectionId core.CollectionId) (core.NoteCollectionId, error) {
+	if !noteId.IsValid() || !collectionId.IsValid() {
+		return 0, fmt.Errorf("Note ID (%d) or collection ID (%d) not valid", noteId, collectionId)
+	}
+
+	res, err := d.createAssociationStmt.Exec(noteId, collectionId)
+	if err != nil {
+		return 0, err
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	return core.NoteCollectionId(id), nil
+}
+
+// RemoveAssociations deletes all associations with the given note.
+func (d *CollectionDAO) RemoveAssociations(noteId core.NoteId) error {
+	if !noteId.IsValid() {
+		return fmt.Errorf("Note ID (%d) not valid", noteId)
+	}
+
+	_, err := d.removeAssociationsStmt.Exec(noteId)
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove associations of note %d", noteId)
+	}
+
+	return nil
+}

--- a/adapter/sqlite/collection_dao.go
+++ b/adapter/sqlite/collection_dao.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/mickael-menu/zk/core"
+	"github.com/mickael-menu/zk/core/note"
 	"github.com/mickael-menu/zk/util"
 	"github.com/mickael-menu/zk/util/errors"
 )
@@ -63,7 +64,7 @@ func NewCollectionDAO(tx Transaction, logger util.Logger) *CollectionDAO {
 
 // FindOrCreate returns the ID of the collection with given kind and name.
 // Creates the collection if it does not already exist.
-func (d *CollectionDAO) FindOrCreate(kind string, name string) (core.CollectionId, error) {
+func (d *CollectionDAO) FindOrCreate(kind note.CollectionKind, name string) (core.CollectionId, error) {
 	id, err := d.findCollection(kind, name)
 
 	switch {
@@ -76,7 +77,7 @@ func (d *CollectionDAO) FindOrCreate(kind string, name string) (core.CollectionI
 	}
 }
 
-func (d *CollectionDAO) findCollection(kind string, name string) (core.CollectionId, error) {
+func (d *CollectionDAO) findCollection(kind note.CollectionKind, name string) (core.CollectionId, error) {
 	wrap := errors.Wrapperf("failed to get %s named %s", kind, name)
 
 	row, err := d.findCollectionStmt.QueryRow(kind, name)
@@ -97,7 +98,7 @@ func (d *CollectionDAO) findCollection(kind string, name string) (core.Collectio
 	}
 }
 
-func (d *CollectionDAO) create(kind string, name string) (core.CollectionId, error) {
+func (d *CollectionDAO) create(kind note.CollectionKind, name string) (core.CollectionId, error) {
 	wrap := errors.Wrapperf("failed to create new %s named %s", kind, name)
 
 	res, err := d.createCollectionStmt.Exec(kind, name)

--- a/adapter/sqlite/collection_dao_test.go
+++ b/adapter/sqlite/collection_dao_test.go
@@ -1,0 +1,72 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/mickael-menu/zk/core"
+	"github.com/mickael-menu/zk/util"
+	"github.com/mickael-menu/zk/util/test/assert"
+)
+
+func TestCollectionDAOFindOrCreate(t *testing.T) {
+	testCollectionDAO(t, func(tx Transaction, dao *CollectionDAO) {
+		// Finds existing ones
+		id, err := dao.FindOrCreate("tag", "adventure")
+		assert.Nil(t, err)
+		assert.Equal(t, id, core.CollectionId(2))
+		id, err = dao.FindOrCreate("genre", "fiction")
+		assert.Nil(t, err)
+		assert.Equal(t, id, core.CollectionId(3))
+
+		// The name is case sensitive
+		id, err = dao.FindOrCreate("tag", "Adventure")
+		assert.Nil(t, err)
+		assert.NotEqual(t, id, core.CollectionId(2))
+
+		// Creates when not found
+		sql := "SELECT id FROM collections WHERE kind = ? AND name = ?"
+		assertNotExist(t, tx, sql, "unknown", "created")
+		id, err = dao.FindOrCreate("unknown", "created")
+		assert.Nil(t, err)
+		assertExist(t, tx, sql, "unknown", "created")
+	})
+}
+
+func TestCollectionDAOAssociate(t *testing.T) {
+	testCollectionDAO(t, func(tx Transaction, dao *CollectionDAO) {
+		// Returns existing association
+		id, err := dao.Associate(1, 2)
+		assert.Nil(t, err)
+		assert.Equal(t, id, core.NoteCollectionId(2))
+
+		// Creates a new association if missing
+		noteId := core.NoteId(5)
+		collectionId := core.CollectionId(3)
+		sql := "SELECT id FROM notes_collections WHERE note_id = ? AND collection_id = ?"
+		assertNotExist(t, tx, sql, noteId, collectionId)
+		_, err = dao.Associate(noteId, collectionId)
+		assert.Nil(t, err)
+		assertExist(t, tx, sql, noteId, collectionId)
+	})
+}
+
+func TestCollectionDAORemoveAssociations(t *testing.T) {
+	testCollectionDAO(t, func(tx Transaction, dao *CollectionDAO) {
+		noteId := core.NoteId(1)
+		sql := "SELECT id FROM notes_collections WHERE note_id = ?"
+		assertExist(t, tx, sql, noteId)
+		err := dao.RemoveAssociations(noteId)
+		assert.Nil(t, err)
+		assertNotExist(t, tx, sql, noteId)
+
+		// Removes associations of note without any.
+		err = dao.RemoveAssociations(999)
+		assert.Nil(t, err)
+	})
+}
+
+func testCollectionDAO(t *testing.T, callback func(tx Transaction, dao *CollectionDAO)) {
+	testTransaction(t, func(tx Transaction) {
+		callback(tx, NewCollectionDAO(tx, &util.NullLogger))
+	})
+}

--- a/adapter/sqlite/db_test.go
+++ b/adapter/sqlite/db_test.go
@@ -33,7 +33,7 @@ func TestMigrateFrom0(t *testing.T) {
 		var version int
 		err := tx.QueryRow("PRAGMA user_version").Scan(&version)
 		assert.Nil(t, err)
-		assert.Equal(t, version, 1)
+		assert.Equal(t, version, 2)
 
 		_, err = tx.Exec(`
 			INSERT INTO notes (path, sortable_path, title, body, word_count, checksum)

--- a/adapter/sqlite/fixtures/default/collections.yml
+++ b/adapter/sqlite/fixtures/default/collections.yml
@@ -7,3 +7,6 @@
 - id: 3
   kind: "genre"
   name: "fiction"
+- id: 4
+  kind: "tag"
+  name: "fantasy"

--- a/adapter/sqlite/fixtures/default/collections.yml
+++ b/adapter/sqlite/fixtures/default/collections.yml
@@ -1,0 +1,9 @@
+- id: 1
+  kind: "tag"
+  name: "fiction"
+- id: 2
+  kind: "tag"
+  name: "adventure"
+- id: 3
+  kind: "genre"
+  name: "fiction"

--- a/adapter/sqlite/fixtures/default/notes_collections.yml
+++ b/adapter/sqlite/fixtures/default/notes_collections.yml
@@ -1,0 +1,9 @@
+- id: 1
+  note_id: 1
+  collection_id: 1
+- id: 2
+  note_id: 1
+  collection_id: 2
+- id: 3
+  note_id: 2
+  collection_id: 3

--- a/adapter/sqlite/note_dao_test.go
+++ b/adapter/sqlite/note_dao_test.go
@@ -235,13 +235,13 @@ func TestNoteDAOAddFillsLinksMissingTargetId(t *testing.T) {
 func TestNoteDAOAddExistingNote(t *testing.T) {
 	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
 		_, err := dao.Add(note.Metadata{Path: "ref/test/a.md"})
-		assert.Err(t, err, "ref/test/a.md: can't add note to the index: UNIQUE constraint failed: notes.path")
+		assert.Err(t, err, "UNIQUE constraint failed: notes.path")
 	})
 }
 
 func TestNoteDAOUpdate(t *testing.T) {
 	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
-		err := dao.Update(note.Metadata{
+		id, err := dao.Update(note.Metadata{
 			Path:       "ref/test/a.md",
 			Title:      "Updated note",
 			Lead:       "Updated lead",
@@ -253,6 +253,7 @@ func TestNoteDAOUpdate(t *testing.T) {
 			Modified:   time.Date(2020, 11, 22, 16, 49, 47, 0, time.UTC),
 		})
 		assert.Nil(t, err)
+		assert.Equal(t, id, core.NoteId(6))
 
 		row, err := queryNoteRow(tx, `path = "ref/test/a.md"`)
 		assert.Nil(t, err)
@@ -272,10 +273,10 @@ func TestNoteDAOUpdate(t *testing.T) {
 
 func TestNoteDAOUpdateUnknown(t *testing.T) {
 	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
-		err := dao.Update(note.Metadata{
+		_, err := dao.Update(note.Metadata{
 			Path: "unknown/unknown.md",
 		})
-		assert.Err(t, err, "unknown/unknown.md: failed to update note index: note not found in the index")
+		assert.Err(t, err, "note not found in the index")
 	})
 }
 
@@ -300,7 +301,7 @@ func TestNoteDAOUpdateWithLinks(t *testing.T) {
 			},
 		})
 
-		err := dao.Update(note.Metadata{
+		_, err := dao.Update(note.Metadata{
 			Path: "log/2021-01-03.md",
 			Links: []note.Link{
 				{
@@ -358,7 +359,7 @@ func TestNoteDAORemove(t *testing.T) {
 func TestNoteDAORemoveUnknown(t *testing.T) {
 	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
 		err := dao.Remove("unknown/unknown.md")
-		assert.Err(t, err, "unknown/unknown.md: failed to remove note index: note not found in the index")
+		assert.Err(t, err, "note not found in the index")
 	})
 }
 

--- a/adapter/sqlite/note_indexer.go
+++ b/adapter/sqlite/note_indexer.go
@@ -1,0 +1,91 @@
+package sqlite
+
+import (
+	"github.com/mickael-menu/zk/core"
+	"github.com/mickael-menu/zk/core/note"
+	"github.com/mickael-menu/zk/util"
+	"github.com/mickael-menu/zk/util/errors"
+	"github.com/mickael-menu/zk/util/paths"
+)
+
+// NoteIndexer persists note indexing results in the SQLite database.
+// It implements the core port note.Indexer and acts as a facade to the DAOs.
+type NoteIndexer struct {
+	tx          Transaction
+	notes       *NoteDAO
+	collections *CollectionDAO
+	logger      util.Logger
+}
+
+func NewNoteIndexer(notes *NoteDAO, collections *CollectionDAO, logger util.Logger) *NoteIndexer {
+	return &NoteIndexer{
+		notes:       notes,
+		collections: collections,
+		logger:      logger,
+	}
+}
+
+// Indexed returns the list of indexed note file metadata.
+func (i *NoteIndexer) Indexed() (<-chan paths.Metadata, error) {
+	c, err := i.notes.Indexed()
+	return c, errors.Wrap(err, "failed to get indexed notes")
+}
+
+// Add indexes a new note from its metadata.
+func (i *NoteIndexer) Add(metadata note.Metadata) (core.NoteId, error) {
+	wrap := errors.Wrapperf("%v: failed to index the note", metadata.Path)
+	noteId, err := i.notes.Add(metadata)
+	if err != nil {
+		return 0, wrap(err)
+	}
+
+	err = i.associateTags(noteId, metadata.Tags)
+	if err != nil {
+		return 0, wrap(err)
+	}
+
+	return noteId, nil
+}
+
+// Update updates the metadata of an already indexed note.
+func (i *NoteIndexer) Update(metadata note.Metadata) error {
+	wrap := errors.Wrapperf("%v: failed to update note index", metadata.Path)
+
+	noteId, err := i.notes.Update(metadata)
+	if err != nil {
+		return wrap(err)
+	}
+
+	err = i.collections.RemoveAssociations(noteId)
+	if err != nil {
+		return wrap(err)
+	}
+
+	err = i.associateTags(noteId, metadata.Tags)
+	if err != nil {
+		return wrap(err)
+	}
+
+	return err
+}
+
+func (i *NoteIndexer) associateTags(noteId core.NoteId, tags []string) error {
+	for _, tag := range tags {
+		tagId, err := i.collections.FindOrCreate(note.CollectionKindTag, tag)
+		if err != nil {
+			return err
+		}
+		_, err = i.collections.Associate(noteId, tagId)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Remove deletes a note from the index.
+func (i *NoteIndexer) Remove(path string) error {
+	err := i.notes.Remove(path)
+	return errors.Wrapf(err, "%v: failed to remove note index", path)
+}

--- a/adapter/sqlite/note_indexer_test.go
+++ b/adapter/sqlite/note_indexer_test.go
@@ -1,0 +1,64 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/mickael-menu/zk/core"
+	"github.com/mickael-menu/zk/core/note"
+	"github.com/mickael-menu/zk/util"
+	"github.com/mickael-menu/zk/util/test/assert"
+)
+
+func TestNoteIndexerAddWithTags(t *testing.T) {
+	testNoteIndexer(t, func(tx Transaction, indexer *NoteIndexer) {
+		assertSQL := func(after bool) {
+			assertTagExistsOrNot(t, tx, true, "fiction")
+			assertTagExistsOrNot(t, tx, after, "new-tag")
+		}
+
+		assertSQL(false)
+		id, err := indexer.Add(note.Metadata{
+			Path: "log/added.md",
+			Tags: []string{"new-tag", "fiction"},
+		})
+		assert.Nil(t, err)
+		assertSQL(true)
+		assertTaggedOrNot(t, tx, true, id, "new-tag")
+		assertTaggedOrNot(t, tx, true, id, "fiction")
+	})
+}
+
+func TestNoteIndexerUpdateWithTags(t *testing.T) {
+	testNoteIndexer(t, func(tx Transaction, indexer *NoteIndexer) {
+		id := core.NoteId(1)
+
+		assertSQL := func(after bool) {
+			assertTaggedOrNot(t, tx, true, id, "fiction")
+			assertTaggedOrNot(t, tx, after, id, "new-tag")
+			assertTaggedOrNot(t, tx, after, id, "fantasy")
+		}
+
+		assertSQL(false)
+		err := indexer.Update(note.Metadata{
+			Path: "log/2021-01-03.md",
+			Tags: []string{"new-tag", "fiction", "fantasy"},
+		})
+		assert.Nil(t, err)
+		assertSQL(true)
+	})
+}
+
+func testNoteIndexer(t *testing.T, callback func(tx Transaction, dao *NoteIndexer)) {
+	testTransaction(t, func(tx Transaction) {
+		logger := &util.NullLogger
+		callback(tx, NewNoteIndexer(NewNoteDAO(tx, logger), NewCollectionDAO(tx, logger), logger))
+	})
+}
+
+func assertTagExistsOrNot(t *testing.T, tx Transaction, shouldExist bool, tag string) {
+	assertExistOrNot(t, tx, shouldExist, "SELECT id FROM collections WHERE kind = 'tag' AND name = ?", tag)
+}
+
+func assertTaggedOrNot(t *testing.T, tx Transaction, shouldBeTagged bool, noteId core.NoteId, tag string) {
+	assertExistOrNot(t, tx, shouldBeTagged, "SELECT id FROM notes_collections WHERE note_id = ? AND collection_id IS (SELECT id FROM collections WHERE kind = 'tag' AND name = ?)", noteId, tag)
+}

--- a/adapter/sqlite/transaction_test.go
+++ b/adapter/sqlite/transaction_test.go
@@ -47,3 +47,22 @@ func testTransactionWithFixtures(t *testing.T, fixturesDir opt.String, test func
 	})
 	assert.Nil(t, err)
 }
+
+func assertExist(t *testing.T, tx Transaction, sql string, args ...interface{}) {
+	if !exists(t, tx, sql, args...) {
+		t.Errorf("SQL query did not return any result: %s, with arguments %v", sql, args)
+	}
+}
+
+func assertNotExist(t *testing.T, tx Transaction, sql string, args ...interface{}) {
+	if exists(t, tx, sql, args...) {
+		t.Errorf("SQL query returned a result: %s, with arguments %v", sql, args)
+	}
+}
+
+func exists(t *testing.T, tx Transaction, sql string, args ...interface{}) bool {
+	var exists int
+	err := tx.QueryRow("SELECT EXISTS ("+sql+")", args...).Scan(&exists)
+	assert.Nil(t, err)
+	return exists == 1
+}

--- a/adapter/sqlite/transaction_test.go
+++ b/adapter/sqlite/transaction_test.go
@@ -48,6 +48,14 @@ func testTransactionWithFixtures(t *testing.T, fixturesDir opt.String, test func
 	assert.Nil(t, err)
 }
 
+func assertExistOrNot(t *testing.T, tx Transaction, shouldExist bool, sql string, args ...interface{}) {
+	if shouldExist {
+		assertExist(t, tx, sql, args...)
+	} else {
+		assertNotExist(t, tx, sql, args...)
+	}
+}
+
 func assertExist(t *testing.T, tx Transaction, sql string, args ...interface{}) {
 	if !exists(t, tx, sql, args...) {
 		t.Errorf("SQL query did not return any result: %s, with arguments %v", sql, args)

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -59,9 +59,9 @@ func (c *Container) TemplateLoader(lang string) *handlebars.Loader {
 
 func (c *Container) Parser() *markdown.Parser {
 	return markdown.NewParser(markdown.ParserOpts{
-		HashtagEnabled:  true,
-		WordTagEnabled:  false,
-		ColontagEnabled: true,
+		HashtagEnabled:      true,
+		MultiWordTagEnabled: false,
+		ColontagEnabled:     true,
 	})
 }
 

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -58,7 +58,9 @@ func (c *Container) TemplateLoader(lang string) *handlebars.Loader {
 }
 
 func (c *Container) Parser() *markdown.Parser {
-	return markdown.NewParser()
+	return markdown.NewParser(markdown.ParserOpts{
+		WordTagEnabled: false,
+	})
 }
 
 func (c *Container) NoteFinder(tx sqlite.Transaction, opts fzf.NoteFinderOpts) *fzf.NoteFinder {

--- a/cmd/container.go
+++ b/cmd/container.go
@@ -59,13 +59,21 @@ func (c *Container) TemplateLoader(lang string) *handlebars.Loader {
 
 func (c *Container) Parser() *markdown.Parser {
 	return markdown.NewParser(markdown.ParserOpts{
-		WordTagEnabled: false,
+		HashtagEnabled:  true,
+		WordTagEnabled:  false,
+		ColontagEnabled: true,
 	})
 }
 
 func (c *Container) NoteFinder(tx sqlite.Transaction, opts fzf.NoteFinderOpts) *fzf.NoteFinder {
 	notes := sqlite.NewNoteDAO(tx, c.Logger)
 	return fzf.NewNoteFinder(opts, notes, c.Terminal)
+}
+
+func (c *Container) NoteIndexer(tx sqlite.Transaction) *sqlite.NoteIndexer {
+	notes := sqlite.NewNoteDAO(tx, c.Logger)
+	collections := sqlite.NewCollectionDAO(tx, c.Logger)
+	return sqlite.NewNoteIndexer(notes, collections, c.Logger)
 }
 
 // Database returns the DB instance for the given notebook, after executing any

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -40,13 +40,11 @@ func (cmd *Index) Run(container *Container) error {
 
 	var stats note.IndexingStats
 	err = db.WithTransaction(func(tx sqlite.Transaction) error {
-		notes := sqlite.NewNoteDAO(tx, container.Logger)
-
 		stats, err = note.Index(
 			zk,
 			cmd.Force,
 			container.Parser(),
-			notes,
+			container.NoteIndexer(tx),
 			container.Logger,
 			func(change paths.DiffChange) {
 				bar.Add(1)

--- a/core/ids.go
+++ b/core/ids.go
@@ -11,3 +11,9 @@ type CollectionId int64
 func (id CollectionId) IsValid() bool {
 	return id > 0
 }
+
+type NoteCollectionId int64
+
+func (id NoteCollectionId) IsValid() bool {
+	return id > 0
+}

--- a/core/ids.go
+++ b/core/ids.go
@@ -1,0 +1,13 @@
+package core
+
+type NoteId int64
+
+func (id NoteId) IsValid() bool {
+	return id > 0
+}
+
+type CollectionId int64
+
+func (id CollectionId) IsValid() bool {
+	return id > 0
+}

--- a/core/note/index.go
+++ b/core/note/index.go
@@ -26,6 +26,7 @@ type Metadata struct {
 	RawContent string
 	WordCount  int
 	Links      []Link
+	Tags       []string
 	Created    time.Time
 	Modified   time.Time
 	Checksum   string
@@ -117,7 +118,8 @@ func Index(zk *zk.Zk, force bool, parser Parser, indexer Indexer, logger util.Lo
 func metadata(path string, zk *zk.Zk, parser Parser) (Metadata, error) {
 	metadata := Metadata{
 		Path:  path,
-		Links: make([]Link, 0),
+		Links: []Link{},
+		Tags:  []string{},
 	}
 
 	absPath := filepath.Join(zk.Path, path)
@@ -136,6 +138,7 @@ func metadata(path string, zk *zk.Zk, parser Parser) (Metadata, error) {
 	metadata.RawContent = contentStr
 	metadata.WordCount = len(strings.Fields(contentStr))
 	metadata.Links = make([]Link, 0)
+	metadata.Tags = contentParts.Tags
 	metadata.Checksum = fmt.Sprintf("%x", sha256.Sum256(content))
 
 	for _, link := range contentParts.Links {

--- a/core/note/index.go
+++ b/core/note/index.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mickael-menu/zk/core"
 	"github.com/mickael-menu/zk/core/zk"
 	"github.com/mickael-menu/zk/util"
 	"github.com/mickael-menu/zk/util/errors"
@@ -57,7 +58,7 @@ type Indexer interface {
 	// Indexed returns the list of indexed note file metadata.
 	Indexed() (<-chan paths.Metadata, error)
 	// Add indexes a new note from its metadata.
-	Add(metadata Metadata) (int64, error)
+	Add(metadata Metadata) (core.NoteId, error)
 	// Update updates the metadata of an already indexed note.
 	Update(metadata Metadata) error
 	// Remove deletes a note from the index.

--- a/core/note/parse.go
+++ b/core/note/parse.go
@@ -39,3 +39,10 @@ const (
 type Parser interface {
 	Parse(source string) (*Content, error)
 }
+
+// CollectionKind defines a kind of note collection, such as tags.
+type CollectionKind string
+
+const (
+	CollectionKindTag CollectionKind = "tag"
+)

--- a/core/note/parse.go
+++ b/core/note/parse.go
@@ -11,10 +11,13 @@ type Content struct {
 	Lead opt.String
 	// Body is the content of the note, including the Lead but without the Title.
 	Body opt.String
+	// Tags is the list of tags found in the note content.
+	Tags []string
 	// Links is the list of outbound links found in the note.
 	Links []Link
 }
 
+// Link links a note to another note or an external resource.
 type Link struct {
 	Title    string
 	Href     string

--- a/docs/.zk/templates/default.md
+++ b/docs/.zk/templates/default.md
@@ -1,2 +1,3 @@
 # {{title}}
 
+{{content}}

--- a/util/strings/strings.go
+++ b/util/strings/strings.go
@@ -75,6 +75,10 @@ func IsURL(s string) bool {
 
 // RemoveDuplicates keeps only unique strings in the source.
 func RemoveDuplicates(strings []string) []string {
+	if strings == nil {
+		return nil
+	}
+
 	check := make(map[string]bool)
 	res := make([]string, 0)
 	for _, val := range strings {

--- a/util/test/assert/assert.go
+++ b/util/test/assert/assert.go
@@ -40,6 +40,15 @@ func Equal(t *testing.T, actual, expected interface{}) {
 	}
 }
 
+func NotEqual(t *testing.T, actual, other interface{}) {
+	if reflect.DeepEqual(actual, other) || cmp.Equal(actual, other) {
+		t.Errorf("Received (type %v):\n% #v", reflect.TypeOf(actual), pretty.Formatter(actual))
+		t.Errorf("\n---\n")
+		t.Errorf("Expected to be different from (type %v):\n% #v", reflect.TypeOf(other), pretty.Formatter(other))
+		t.Errorf("\n---\n")
+	}
+}
+
 func toJSON(t *testing.T, obj interface{}) string {
 	json, err := json.Marshal(obj)
 	// json, err := json.MarshalIndent(obj, "", "  ")


### PR DESCRIPTION
Fix #2

Many tag flavors are supported: `#hashtags`, `:colon:separated:tags:` and even Bear's [`#multi-word tags#`](https://blog.bear.app/2017/11/bear-tips-how-to-create-multi-word-tags/). If you prefer to use a YAML frontmatter, list your tags with the keys `tags` or `keywords`.

## Technical notes

I created a generic `collections` table with a `kind` column (e.g. `tag`) to hold the tags. In the future, this could be extended for other kinds of metadata (categories, author, etc.).