### PR TITLE
Add a global configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+* Global `zk` configuration at `~/.config/zk/config.toml`.
+    * Useful to share aliases or default settings across several [notebooks](docs/notebook.md).
+    * This is the same format as a notebook [configuration file](docs/config.md).
+    * Shared templates can be stored in `~/.config/zk/templates/`.
+    * `XDG_CONFIG_HOME` is taken into account.
+
 
 ## 0.2.1
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -21,7 +21,7 @@ type Edit struct {
 }
 
 func (cmd *Edit) Run(container *Container) error {
-	zk, err := container.OpenZk()
+	zk, err := container.Zk()
 	if err != nil {
 		return err
 	}

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -15,7 +15,7 @@ func (cmd *Index) Help() string {
 }
 
 func (cmd *Index) Run(container *Container) error {
-	zk, err := container.OpenZk()
+	zk, err := container.Zk()
 	if err != nil {
 		return err
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,7 +29,7 @@ func (cmd *List) Run(container *Container) error {
 		cmd.Delimiter = "\x00"
 	}
 
-	zk, err := container.OpenZk()
+	zk, err := container.Zk()
 	if err != nil {
 		return err
 	}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -46,6 +46,7 @@ func (cmd *New) Run(container *Container) error {
 	}
 
 	opts := note.CreateOpts{
+		Config:  zk.Config,
 		Dir:     *dir,
 		Title:   opt.NewNotEmptyString(cmd.Title),
 		Content: content,

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -30,7 +30,7 @@ func (cmd *New) ConfigOverrides() zk.ConfigOverrides {
 }
 
 func (cmd *New) Run(container *Container) error {
-	zk, err := container.OpenZk()
+	zk, err := container.Zk()
 	if err != nil {
 		return err
 	}

--- a/core/note/create.go
+++ b/core/note/create.go
@@ -17,6 +17,8 @@ import (
 
 // CreateOpts holds the options to create a new note.
 type CreateOpts struct {
+	// Current configuration.
+	Config zk.Config
 	// Parent directory for the new note.
 	Dir zk.Dir
 	// Title of the note.
@@ -52,7 +54,11 @@ func Create(
 
 	var bodyTemplate templ.Renderer = templ.NullRenderer
 	if templatePath := opts.Dir.Config.Note.BodyTemplatePath.Unwrap(); templatePath != "" {
-		bodyTemplate, err = templateLoader.LoadFile(templatePath)
+		absPath, ok := opts.Config.LocateTemplate(templatePath)
+		if !ok {
+			return "", wrap(fmt.Errorf("%s: cannot find template", templatePath))
+		}
+		bodyTemplate, err = templateLoader.LoadFile(absPath)
 		if err != nil {
 			return "", wrap(err)
 		}

--- a/core/zk/config.go
+++ b/core/zk/config.go
@@ -1,7 +1,6 @@
 package zk
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -69,7 +68,6 @@ func (c Config) LocateTemplate(path string) (string, bool) {
 	}
 
 	exists := func(path string) bool {
-		fmt.Println("Check exists", path)
 		exists, err := paths.Exists(path)
 		return exists && err == nil
 	}
@@ -265,7 +263,7 @@ func ParseConfig(content []byte, path string, parentConfig Config) (Config, erro
 		}
 	}
 
-	config.TemplatesDirs = append(config.TemplatesDirs, filepath.Join(filepath.Dir(path), "templates"))
+	config.TemplatesDirs = append([]string{filepath.Join(filepath.Dir(path), "templates")}, config.TemplatesDirs...)
 
 	return config, nil
 }

--- a/core/zk/config_test.go
+++ b/core/zk/config_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func TestParseDefaultConfig(t *testing.T) {
-	conf, err := ParseConfig([]byte(""), ".zk/config.toml")
+	conf, err := ParseConfig([]byte(""), ".zk/config.toml", NewDefaultConfig())
 
 	assert.Nil(t, err)
-	assert.Equal(t, conf, &Config{
+	assert.Equal(t, conf, Config{
 		Note: NoteConfig{
 			FilenameTemplate: "{{id}}",
 			Extension:        "md",
@@ -49,10 +49,8 @@ func TestParseDefaultConfig(t *testing.T) {
 }
 
 func TestParseInvalidConfig(t *testing.T) {
-	conf, err := ParseConfig([]byte(`;`), ".zk/config.toml")
-
+	_, err := ParseConfig([]byte(`;`), ".zk/config.toml", NewDefaultConfig())
 	assert.NotNil(t, err)
-	assert.Nil(t, conf)
 }
 
 func TestParseComplete(t *testing.T) {
@@ -108,10 +106,10 @@ func TestParseComplete(t *testing.T) {
 
 		[group."without path"]
 		paths = []
-	`), ".zk/config.toml")
+	`), ".zk/config.toml", NewDefaultConfig())
 
 	assert.Nil(t, err)
-	assert.Equal(t, conf, &Config{
+	assert.Equal(t, conf, Config{
 		Note: NoteConfig{
 			FilenameTemplate: "{{id}}.note",
 			Extension:        "txt",
@@ -236,10 +234,10 @@ func TestParseMergesGroupConfig(t *testing.T) {
 		log-ext = "value"
 
 		[group.inherited]
-	`), ".zk/config.toml")
+	`), ".zk/config.toml", NewDefaultConfig())
 
 	assert.Nil(t, err)
-	assert.Equal(t, conf, &Config{
+	assert.Equal(t, conf, Config{
 		Note: NoteConfig{
 			FilenameTemplate: "root-filename",
 			Extension:        "txt",
@@ -316,7 +314,7 @@ func TestParsePreservePropertiesAllowingEmptyValues(t *testing.T) {
 		[tool]
 		pager = ""
 		fzf-preview = ""
-	`), ".zk/config.toml")
+	`), ".zk/config.toml", NewDefaultConfig())
 
 	assert.Nil(t, err)
 	assert.Equal(t, conf.Tool.Pager.IsNull(), false)
@@ -331,7 +329,7 @@ func TestParseIDCharset(t *testing.T) {
 			[note]
 			id-charset = "%v"
 		`, charset)
-		conf, err := ParseConfig([]byte(toml), ".zk/config.toml")
+		conf, err := ParseConfig([]byte(toml), ".zk/config.toml", NewDefaultConfig())
 		assert.Nil(t, err)
 		if !cmp.Equal(conf.Note.IDOptions.Charset, expected) {
 			t.Errorf("Didn't parse ID charset `%v` as expected", charset)
@@ -352,7 +350,7 @@ func TestParseIDCase(t *testing.T) {
 			[note]
 			id-case = "%v"
 		`, letterCase)
-		conf, err := ParseConfig([]byte(toml), ".zk/config.toml")
+		conf, err := ParseConfig([]byte(toml), ".zk/config.toml", NewDefaultConfig())
 		assert.Nil(t, err)
 		if !cmp.Equal(conf.Note.IDOptions.Case, expected) {
 			t.Errorf("Didn't parse ID case `%v` as expected", letterCase)
@@ -371,7 +369,7 @@ func TestLocateTemplate(t *testing.T) {
 	os.MkdirAll(filepath.Join(root, "templates"), os.ModePerm)
 
 	test := func(template string, expected string, exists bool) {
-		conf, err := ParseConfig([]byte(""), filepath.Join(root, "config.toml"))
+		conf, err := ParseConfig([]byte(""), filepath.Join(root, "config.toml"), NewDefaultConfig())
 		assert.Nil(t, err)
 
 		path, ok := conf.LocateTemplate(template)

--- a/core/zk/zk.go
+++ b/core/zk/zk.go
@@ -177,7 +177,7 @@ type Dir struct {
 }
 
 // Open locates a notebook at the given path and parses its configuration.
-func Open(path string) (*Zk, error) {
+func Open(path string, parentConfig Config) (*Zk, error) {
 	wrap := errors.Wrapper("open failed")
 
 	path, err := filepath.Abs(path)
@@ -189,7 +189,7 @@ func Open(path string) (*Zk, error) {
 		return nil, wrap(err)
 	}
 
-	config, err := OpenConfig(filepath.Join(path, ".zk/config.toml"), NewDefaultConfig())
+	config, err := OpenConfig(filepath.Join(path, ".zk/config.toml"), parentConfig)
 	if err != nil {
 		return nil, wrap(err)
 	}

--- a/core/zk/zk.go
+++ b/core/zk/zk.go
@@ -2,7 +2,6 @@ package zk
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 
@@ -190,13 +189,7 @@ func Open(path string) (*Zk, error) {
 		return nil, wrap(err)
 	}
 
-	configContent, err := ioutil.ReadFile(filepath.Join(path, ".zk/config.toml"))
-	if err != nil {
-		return nil, wrap(err)
-	}
-
-	templatesDir := filepath.Join(path, ".zk/templates")
-	config, err := ParseConfig(configContent, templatesDir)
+	config, err := OpenConfig(filepath.Join(path, ".zk/config.toml"))
 	if err != nil {
 		return nil, wrap(err)
 	}

--- a/core/zk/zk.go
+++ b/core/zk/zk.go
@@ -189,14 +189,14 @@ func Open(path string) (*Zk, error) {
 		return nil, wrap(err)
 	}
 
-	config, err := OpenConfig(filepath.Join(path, ".zk/config.toml"))
+	config, err := OpenConfig(filepath.Join(path, ".zk/config.toml"), NewDefaultConfig())
 	if err != nil {
 		return nil, wrap(err)
 	}
 
 	return &Zk{
 		Path:   path,
-		Config: *config,
+		Config: config,
 	}, nil
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,12 @@ Each [notebook](notebook.md) contains a configuration file used to customize you
     * [`fzf`](tool-fzf.md)
 * `[alias]` holds your [command aliases](config-alias.md)
 
+## Global configuration file
+
+You can also create a global configuration file to share aliases and settings across several notebooks. The global configuration is by default located at `~/.config/zk/config.toml`, but you can customize its location with the [`XDG_CONFIG_HOME`](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) environment variable.
+
+Notebook configuration files will inherit the settings defined in the global configuration file. You can also share templates by storing them under `~/.config/zk/templates/`.
+
 ## Complete example
 
 Here's an example of a complete configuration file:

--- a/util/test/assert/assert.go
+++ b/util/test/assert/assert.go
@@ -10,6 +10,18 @@ import (
 	"github.com/mickael-menu/pretty"
 )
 
+func True(t *testing.T, value bool) {
+	if !value {
+		t.Errorf("Expected to be true")
+	}
+}
+
+func False(t *testing.T, value bool) {
+	if value {
+		t.Errorf("Expected to be false")
+	}
+}
+
 func Nil(t *testing.T, value interface{}) {
 	if !isNil(value) {
 		t.Errorf("Expected `%v` (type %v) to be nil", value, reflect.TypeOf(value))


### PR DESCRIPTION
Fix #10 

* Global `zk` configuration at `~/.config/zk/config.toml`.
    * Useful to share aliases or default settings across several notebooks.
    * This is the same format as a notebook configuration file.
    * Shared templates can be stored in `~/.config/zk/templates/`.
    * `XDG_CONFIG_HOME` is taken into account.
