### PR TITLE
Specify the notebook directory explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 * Use `--notebook-dir` or set `ZK_NOTEBOOK_DIR` to run `zk` as if it was started from this path instead of the current working directory.
     * This allows running `zk` without being in a notebook.
     * By setting `ZK_NOTEBOOK_DIR` in your shell configuration file (e.g. `~/.profile`), you are declaring a default global notebook which will be used when `zk` is not in a notebook.
+    * When the notebook directory is set explicitly, any path given as argument will be relative to it instead of the actual working directory.
 
 
 ## 0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
     * This is the same format as a notebook [configuration file](docs/config.md).
     * Shared templates can be stored in `~/.config/zk/templates/`.
     * `XDG_CONFIG_HOME` is taken into account.
+* Use `--notebook-dir` or set `ZK_NOTEBOOK_DIR` to run `zk` as if it was started from this path instead of the current working directory.
+    * This allows running `zk` without being in a notebook.
+    * By setting `ZK_NOTEBOOK_DIR` in your shell configuration file (e.g. `~/.profile`), you are declaring a default global notebook which will be used when `zk` is not in a notebook.
 
 
 ## 0.2.1

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -36,7 +36,7 @@ func (cmd *Edit) Run(container *Container) error {
 		return errors.Wrapf(err, "incorrect criteria")
 	}
 
-	db, _, err := container.Database(zk, false)
+	db, _, err := container.Database(false)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (cmd *Edit) Run(container *Container) error {
 	err = db.WithTransaction(func(tx sqlite.Transaction) error {
 		finder := container.NoteFinder(tx, fzf.NoteFinderOpts{
 			AlwaysFilter: true,
-			PreviewCmd:   zk.Config.Tool.FzfPreview,
+			PreviewCmd:   container.Config.Tool.FzfPreview,
 			NewNoteDir:   cmd.newNoteDir(zk),
 			BasePath:     zk.Path,
 			CurrentPath:  wd,

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/mickael-menu/zk/adapter/fzf"
@@ -26,11 +25,6 @@ func (cmd *Edit) Run(container *Container) error {
 		return err
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
 	opts, err := NewFinderOpts(zk, cmd.Filtering, cmd.Sorting)
 	if err != nil {
 		return errors.Wrapf(err, "incorrect criteria")
@@ -48,7 +42,7 @@ func (cmd *Edit) Run(container *Container) error {
 			PreviewCmd:   container.Config.Tool.FzfPreview,
 			NewNoteDir:   cmd.newNoteDir(zk),
 			BasePath:     zk.Path,
-			CurrentPath:  wd,
+			CurrentPath:  container.WorkingDir,
 		})
 		notes, err = finder.Find(*opts)
 		return err

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -15,12 +15,7 @@ func (cmd *Index) Help() string {
 }
 
 func (cmd *Index) Run(container *Container) error {
-	zk, err := container.Zk()
-	if err != nil {
-		return err
-	}
-
-	_, stats, err := container.Database(zk, cmd.Force)
+	_, stats, err := container.Database(cmd.Force)
 	if err != nil {
 		return err
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,7 +39,7 @@ func (cmd *List) Run(container *Container) error {
 		return err
 	}
 
-	db, _, err := container.Database(zk, false)
+	db, _, err := container.Database(false)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func (cmd *List) Run(container *Container) error {
 		return err
 	}
 
-	templates := container.TemplateLoader(zk.Config.Note.Lang)
+	templates := container.TemplateLoader(container.Config.Note.Lang)
 	styler := container.Terminal
 	format := opt.NewNotEmptyString(cmd.Format)
 	formatter, err := note.NewFormatter(zk.Path, wd, format, templates, styler)
@@ -61,7 +61,7 @@ func (cmd *List) Run(container *Container) error {
 	err = db.WithTransaction(func(tx sqlite.Transaction) error {
 		finder := container.NoteFinder(tx, fzf.NoteFinderOpts{
 			AlwaysFilter: false,
-			PreviewCmd:   zk.Config.Tool.FzfPreview,
+			PreviewCmd:   container.Config.Tool.FzfPreview,
 			BasePath:     zk.Path,
 			CurrentPath:  wd,
 		})
@@ -77,7 +77,7 @@ func (cmd *List) Run(container *Container) error {
 
 	count := len(notes)
 	if count > 0 {
-		err = container.Paginate(cmd.NoPager, zk.Config, func(out io.Writer) error {
+		err = container.Paginate(cmd.NoPager, func(out io.Writer) error {
 			for i, note := range notes {
 				if i > 0 {
 					fmt.Fprint(out, cmd.Delimiter)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -44,15 +44,10 @@ func (cmd *List) Run(container *Container) error {
 		return err
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
 	templates := container.TemplateLoader(container.Config.Note.Lang)
 	styler := container.Terminal
 	format := opt.NewNotEmptyString(cmd.Format)
-	formatter, err := note.NewFormatter(zk.Path, wd, format, templates, styler)
+	formatter, err := note.NewFormatter(zk.Path, container.WorkingDir, format, templates, styler)
 	if err != nil {
 		return err
 	}
@@ -63,7 +58,7 @@ func (cmd *List) Run(container *Container) error {
 			AlwaysFilter: false,
 			PreviewCmd:   container.Config.Tool.FzfPreview,
 			BasePath:     zk.Path,
-			CurrentPath:  wd,
+			CurrentPath:  container.WorkingDir,
 		})
 		notes, err = finder.Find(*opts)
 		return err

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -46,7 +46,7 @@ func (cmd *New) Run(container *Container) error {
 	}
 
 	opts := note.CreateOpts{
-		Config:  zk.Config,
+		Config:  container.Config,
 		Dir:     *dir,
 		Title:   opt.NewNotEmptyString(cmd.Title),
 		Content: content,

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -12,7 +12,7 @@ import (
 
 // New adds a new note to the notebook.
 type New struct {
-	Directory string `arg optional type:"path" default:"." help:"Directory in which to create the note."`
+	Directory string `arg optional default:"." help:"Directory in which to create the note."`
 
 	Title     string            `short:t   placeholder:TITLE help:"Title of the new note."`
 	Group     string            `short:g   placeholder:NAME  help:"Name of the config group this note belongs to. Takes precedence over the config of the directory."`

--- a/core/zk/zk.go
+++ b/core/zk/zk.go
@@ -9,6 +9,13 @@ import (
 	"github.com/mickael-menu/zk/util/paths"
 )
 
+// ErrNotebookNotFound is an error returned when a notebook cannot be found at the given path or its parents.
+type ErrNotebookNotFound string
+
+func (e ErrNotebookNotFound) Error() string {
+	return fmt.Sprintf("no notebook found in %s or a parent directory", string(e))
+}
+
 const defaultConfig = `# zk configuration file
 #
 # Uncomment the properties you want to customize.
@@ -150,7 +157,7 @@ hashtags = true
 #hist = "zk list --format path --delimiter0 --quiet $@ | xargs -t -0 git log --patch --"
 
 # Edit this configuration file.
-#conf = '$EDITOR "$ZK_PATH/.zk/config.toml"'
+#conf = '$EDITOR "$ZK_NOTEBOOK_DIR/.zk/config.toml"'
 `
 
 const defaultTemplate = `# {{title}}
@@ -237,7 +244,7 @@ func locateRoot(path string) (string, error) {
 	var locate func(string) (string, error)
 	locate = func(currentPath string) (string, error) {
 		if currentPath == "/" || currentPath == "." {
-			return "", fmt.Errorf("no notebook found in %v or a parent directory", path)
+			return "", ErrNotebookNotFound(path)
 		}
 		exists, err := paths.DirExists(filepath.Join(currentPath, ".zk"))
 		switch {

--- a/docs/config-alias.md
+++ b/docs/config-alias.md
@@ -20,10 +20,10 @@ An alias can call other aliases but cannot call itself. This enables you to over
 edit = "zk edit --interactive $@"
 ```
 
-When running an alias, the `ZK_PATH` environment variable is set to the absolute path of the current notebook. You can use it to run commands working no matter the location of the working directory.
+When running an alias, the `ZK_NOTEBOOK_DIR` environment variable is set to the absolute path of the current notebook. You can use it to run commands working no matter the location of the working directory.
 
 ```toml
-journal = 'zk new "$ZK_PATH/journal"'
+journal = 'zk new "$ZK_NOTEBOOK_DIR/journal"'
 ```
 
 If you need to surround the path with quotes, make sure you use double quotes, otherwise environment variables will not be expanded.
@@ -70,10 +70,10 @@ recent = "zk edit --sort created- --created-after 'last two weeks' --interactive
 
 ### Edit the configuration file
 
-Here's a concrete example using environment variables, in particular `ZK_PATH`. Note the double quotes around the path.
+Here's a concrete example using environment variables, in particular `ZK_NOTEBOOK_DIR`. Note the double quotes around the path.
 
 ```toml
-conf = '$EDITOR "$ZK_PATH/.zk/config.toml"'
+conf = '$EDITOR "$ZK_NOTEBOOK_DIR/.zk/config.toml"'
 ```
 
 ### List paths in a command-line friendly fashion

--- a/docs/daily-journal.md
+++ b/docs/daily-journal.md
@@ -34,12 +34,12 @@ That is a bit of a mouthful for a command called every day. Would it not be bett
 
 ```toml
 [alias]
-daily = 'zk new --no-input "$ZK_PATH/journal/daily"'
+daily = 'zk new --no-input "$ZK_NOTEBOOK_DIR/journal/daily"'
 ```
 
 Let's unpack this alias:
 
 * `zk new` will refuse to overwrite notes. If you already created today's note, it will instead ask you if you wish to edit it. Using `--no-input` skips the prompt and edit the existing note right away.
-* `$ZK_PATH` is set to the absolute path of the current [notebook](notebook.md) when running an alias. Using it allows you to run `zk daily` no matter where you are in the notebook folder hierarchy.
-* We need to use double quotes around `$ZK_PATH`, otherwise it will not be expanded.
+* `$ZK_NOTEBOOK_DIR` is set to the absolute path of the current [notebook](notebook.md) when running an alias. Using it allows you to run `zk daily` no matter where you are in the notebook folder hierarchy.
+* We need to use double quotes around `$ZK_NOTEBOOK_DIR`, otherwise it will not be expanded.
 

--- a/docs/notebook.md
+++ b/docs/notebook.md
@@ -4,7 +4,7 @@ A *notebook* is a directory containing a collection of notes managed by `zk`. No
 
 To create a new notebook, simply run `zk init [<directory>]`.
 
-Most `zk` commands are operating "Git-style" on the notebook containing the current working directory (or one of its parents).
+Most `zk` commands are operating "Git-style" on the notebook containing the current working directory (or one of its parents). However, you can explicitly set which notebook to use with `--notebook-dir` or the `ZK_NOTEBOOK_DIR` environment variable. Setting `ZK_NOTEBOOK_DIR` in your shell configuration (e.g. `~/.profile`) can be used to define a default notebook which `zk` commands will use when the working directory is not in another notebook.
 
 ## Anatomy of a notebook
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/mickael-menu/zk/cmd"
@@ -118,6 +117,10 @@ func runAlias(container *cmd.Container, args []string) (bool, error) {
 
 		// Prevent infinite loop if an alias calls itself.
 		os.Setenv("ZK_RUNNING_ALIAS", alias)
+
+		// Move to the provided working directory if it is not the current one,
+		// before running the alias.
+		cmdStr = `cd "` + container.WorkingDir + `" && ` + cmdStr
 
 		cmd := executil.CommandFromString(cmdStr, args[1:]...)
 		cmd.Stdin = os.Stdin

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -23,7 +24,8 @@ var cli struct {
 	List cmd.List `cmd group:"notes" help:"List notes matching the given criteria."`
 	Edit cmd.Edit `cmd group:"notes" help:"Edit notes matching the given criteria."`
 
-	NoInput NoInput `help:"Never prompt or ask for confirmation."`
+	NoInput     NoInput `help:"Never prompt or ask for confirmation."`
+	NotebookDir string  `placeholder:"PATH" help:"Run as if zk was started in <PATH> instead of the current working directory."`
 
 	ShowHelp ShowHelp         `cmd default:"1" hidden:true`
 	Version  kong.VersionFlag `help:"Print zk version." hidden:true`
@@ -57,9 +59,14 @@ func main() {
 	container, err := cmd.NewContainer()
 	fatalIfError(err)
 
+	// Open the notebook if there's any.
+	searchPaths, err := notebookSearchPaths()
+	fatalIfError(err)
+	container.OpenNotebook(searchPaths)
+
+	// Run the alias or command.
 	if isAlias, err := runAlias(container, os.Args[1:]); isAlias {
 		fatalIfError(err)
-
 	} else {
 		ctx := kong.Parse(&cli, options(container)...)
 		err := ctx.Run(container)
@@ -129,4 +136,60 @@ func runAlias(container *cmd.Container, args []string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// notebookSearchPaths returns the places where zk will look for a notebook.
+// The first successful candidate will be used as the working directory from
+// which path arguments are relative from.
+//
+// By order of precedence:
+//   1. --notebook-dir flag
+//   2. current working directory
+//   3. ZK_NOTEBOOK_DIR environment variable
+func notebookSearchPaths() ([]string, error) {
+	// 1. --notebook-dir flag
+	notebookDir, err := parseNotebookDirFlag()
+	if err != nil {
+		return []string{}, err
+	}
+	if notebookDir != "" {
+		// If --notebook-dir is used, we want to only check there to report errors.
+		return []string{notebookDir}, nil
+	}
+
+	candidates := []string{}
+
+	// 2. current working directory
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	candidates = append(candidates, wd)
+
+	// 3. ZK_NOTEBOOK_DIR environment variable
+	if notebookDir, ok := os.LookupEnv("ZK_NOTEBOOK_DIR"); ok {
+		candidates = append(candidates, notebookDir)
+	}
+
+	return candidates, nil
+}
+
+// parseNotebookDir returns the path to the notebook specified with the
+// --notebook-dir flag.
+//
+// We need to parse the --notebook-dir flag before Kong, because we might need
+// it to resolve zk command aliases before parsing the CLI.
+func parseNotebookDirFlag() (string, error) {
+	foundFlag := false
+	for _, arg := range os.Args {
+		if arg == "--notebook-dir" {
+			foundFlag = true
+		} else if foundFlag {
+			return arg, nil
+		}
+	}
+	if foundFlag {
+		return "", errors.New("--notebook-dir requires an argument")
+	}
+	return "", nil
 }


### PR DESCRIPTION
Fix #13

* Use `--notebook-dir` or set `ZK_NOTEBOOK_DIR` to run `zk` as if it was started from this path instead of the current working directory.
    * This allows running `zk` without being in a notebook.
    * By setting `ZK_NOTEBOOK_DIR` in your shell configuration file (e.g. `~/.profile`), you are declaring a default global notebook which will be used when `zk` is not in a notebook.
    * When the notebook directory is set explicitly, any path given as argument will be relative to it instead of the actual working directory.