### PR TITLE
Add --working-dir option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 * The local configuration is not required anymore in a notebook's `.zk` directory.
-
+* `--notebook-dir` does not change the working directory anymore, instead it sets manually the current notebook and disable auto-discovery. Use the new `--working-dir`/`-W` flag to run `zk` as if it was started from this path instead of the current working directory.
+    * For convenience, `ZK_NOTEBOOK_DIR` behaves like setting a `--working-dir` fallback, instead of `--notebook-dir`. This way, paths will be relative to the root of the notebook.
+    * A practical use case is to use `zk list -W .` when outside a notebook. This will list the notes in `ZK_NOTEBOOK_DIR` but print paths relative to the current directory, making them actionable from your terminal emulator.
 
 ## 0.3.0
 

--- a/internal/adapter/fs/fs.go
+++ b/internal/adapter/fs/fs.go
@@ -12,7 +12,7 @@ import (
 // FileStorage implements the port core.FileStorage.
 type FileStorage struct {
 	// Current working directory.
-	WorkingDir string
+	workingDir string
 	logger     util.Logger
 }
 
@@ -30,10 +30,18 @@ func NewFileStorage(workingDir string, logger util.Logger) (*FileStorage, error)
 	return &FileStorage{workingDir, logger}, nil
 }
 
+func (fs *FileStorage) WorkingDir() string {
+	return fs.workingDir
+}
+
+func (fs *FileStorage) SetWorkingDir(path string) {
+	fs.workingDir = path
+}
+
 func (fs *FileStorage) Abs(path string) (string, error) {
 	var err error
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(fs.WorkingDir, path)
+		path = filepath.Join(fs.workingDir, path)
 		path, err = filepath.Abs(path)
 		if err != nil {
 			return path, err
@@ -44,7 +52,7 @@ func (fs *FileStorage) Abs(path string) (string, error) {
 }
 
 func (fs *FileStorage) Rel(path string) (string, error) {
-	return filepath.Rel(fs.WorkingDir, path)
+	return filepath.Rel(fs.workingDir, path)
 }
 
 func (fs *FileStorage) Canonical(path string) string {

--- a/internal/cli/cmd/edit.go
+++ b/internal/cli/cmd/edit.go
@@ -38,7 +38,6 @@ func (cmd *Edit) Run(container *cli.Container) error {
 		PreviewCmd:   container.Config.Tool.FzfPreview,
 		NewNoteDir:   cmd.newNoteDir(notebook),
 		NotebookDir:  notebook.Path,
-		WorkingDir:   container.WorkingDir,
 	})
 
 	notes, err = filter.Apply(notes)

--- a/internal/cli/cmd/list.go
+++ b/internal/cli/cmd/list.go
@@ -52,7 +52,6 @@ func (cmd *List) Run(container *cli.Container) error {
 		AlwaysFilter: false,
 		PreviewCmd:   container.Config.Tool.FzfPreview,
 		NotebookDir:  notebook.Path,
-		WorkingDir:   container.WorkingDir,
 	})
 
 	notes, err = filter.Apply(notes)

--- a/internal/core/fs.go
+++ b/internal/core/fs.go
@@ -3,6 +3,9 @@ package core
 // FileStorage is a port providing read and write access to a file storage.
 type FileStorage interface {
 
+	// WorkingDir returns the current working directory.
+	WorkingDir() string
+
 	// Abs makes the given file path absolute if needed, using the FileStorage
 	// working directory.
 	Abs(path string) (string, error)

--- a/internal/core/fs_test.go
+++ b/internal/core/fs_test.go
@@ -8,25 +8,29 @@ import (
 // fileStorageMock implements an in-memory FileStorage for testing purposes.
 type fileStorageMock struct {
 	// Working directory used to calculate relative paths.
-	WorkingDir string
+	workingDir string
 	// File content indexed by their path in this file storage.
-	Files map[string]string
+	files map[string]string
 	// Existing directories
-	Dirs []string
+	dirs []string
 }
 
 func newFileStorageMock(workingDir string, dirs []string) *fileStorageMock {
 	return &fileStorageMock{
-		WorkingDir: workingDir,
-		Files:      map[string]string{},
-		Dirs:       dirs,
+		workingDir: workingDir,
+		files:      map[string]string{},
+		dirs:       dirs,
 	}
+}
+
+func (fs *fileStorageMock) WorkingDir() string {
+	return fs.workingDir
 }
 
 func (fs *fileStorageMock) Abs(path string) (string, error) {
 	var err error
 	if !filepath.IsAbs(path) {
-		path = filepath.Join(fs.WorkingDir, path)
+		path = filepath.Join(fs.workingDir, path)
 		path, err = filepath.Abs(path)
 		if err != nil {
 			return path, err
@@ -37,7 +41,7 @@ func (fs *fileStorageMock) Abs(path string) (string, error) {
 }
 
 func (fs *fileStorageMock) Rel(path string) (string, error) {
-	return filepath.Rel(fs.WorkingDir, path)
+	return filepath.Rel(fs.workingDir, path)
 }
 
 func (fs *fileStorageMock) Canonical(path string) string {
@@ -45,12 +49,12 @@ func (fs *fileStorageMock) Canonical(path string) string {
 }
 
 func (fs *fileStorageMock) FileExists(path string) (bool, error) {
-	_, ok := fs.Files[path]
+	_, ok := fs.files[path]
 	return ok, nil
 }
 
 func (fs *fileStorageMock) DirExists(path string) (bool, error) {
-	for _, dir := range fs.Dirs {
+	for _, dir := range fs.dirs {
 		if dir == path {
 			return true, nil
 		}
@@ -67,11 +71,11 @@ func (fs *fileStorageMock) IsDescendantOf(dir string, path string) (bool, error)
 }
 
 func (fs *fileStorageMock) Read(path string) ([]byte, error) {
-	content, _ := fs.Files[path]
+	content, _ := fs.files[path]
 	return []byte(content), nil
 }
 
 func (fs *fileStorageMock) Write(path string, content []byte) error {
-	fs.Files[path] = string(content)
+	fs.files[path] = string(content)
 	return nil
 }

--- a/internal/core/note_new_test.go
+++ b/internal/core/note_new_test.go
@@ -29,7 +29,7 @@ func TestNotebookNewNote(t *testing.T) {
 	assert.Equal(t, path, "/notebook/filename.ext")
 
 	// Check created note.
-	assert.Equal(t, test.fs.Files[path], "body")
+	assert.Equal(t, test.fs.files[path], "body")
 
 	assert.Equal(t, test.receivedLang, test.config.Note.Lang)
 	assert.Equal(t, test.receivedIDOpts, test.config.Note.IDOptions)
@@ -115,7 +115,7 @@ func TestNotebookNewNoteInDir(t *testing.T) {
 	assert.Equal(t, path, "/notebook/a-dir/filename.ext")
 
 	// Check created note.
-	assert.Equal(t, test.fs.Files[path], "body")
+	assert.Equal(t, test.fs.files[path], "body")
 
 	// Check that the templates received the proper render contexts.
 	assert.Equal(t, test.filenameTemplate.Contexts, []interface{}{
@@ -189,7 +189,7 @@ func TestNotebookNewNoteInDirWithGroup(t *testing.T) {
 	assert.Equal(t, path, "/notebook/a-dir/group-filename.group-ext")
 
 	// Check created note.
-	assert.Equal(t, test.fs.Files[path], "group template body")
+	assert.Equal(t, test.fs.files[path], "group template body")
 
 	assert.Equal(t, test.receivedLang, groupConfig.Note.Lang)
 	assert.Equal(t, test.receivedIDOpts, groupConfig.Note.IDOptions)
@@ -264,7 +264,7 @@ func TestNotebookNewNoteWithGroup(t *testing.T) {
 	assert.Equal(t, path, "/notebook/group-filename.group-ext")
 
 	// Check created note.
-	assert.Equal(t, test.fs.Files[path], "group template body")
+	assert.Equal(t, test.fs.files[path], "group template body")
 
 	assert.Equal(t, test.receivedLang, groupConfig.Note.Lang)
 	assert.Equal(t, test.receivedIDOpts, groupConfig.Note.IDOptions)
@@ -325,7 +325,7 @@ func TestNotebookNewNoteWithCustomTemplate(t *testing.T) {
 	})
 
 	assert.Nil(t, err)
-	assert.Equal(t, test.fs.Files[path], "custom body template")
+	assert.Equal(t, test.fs.files[path], "custom body template")
 }
 
 // Tries to generate a filename until one is free.
@@ -352,7 +352,7 @@ func TestNotebookNewNoteTriesUntilFreePath(t *testing.T) {
 	assert.Equal(t, path, "/notebook/filename4.ext")
 
 	// Check created note.
-	assert.Equal(t, test.fs.Files[path], "body")
+	assert.Equal(t, test.fs.files[path], "body")
 }
 
 func TestNotebookNewNoteErrorWhenNoFreePath(t *testing.T) {
@@ -375,7 +375,7 @@ func TestNotebookNewNoteErrorWhenNoFreePath(t *testing.T) {
 	})
 
 	assert.Err(t, err, "/notebook/filename50.ext: note already exists")
-	assert.Equal(t, test.fs.Files, files)
+	assert.Equal(t, test.fs.files, files)
 }
 
 var now = time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
@@ -409,7 +409,7 @@ func (t *newNoteTest) setup() {
 	t.dirs = append(t.dirs, t.rootDir)
 	t.fs = newFileStorageMock(t.rootDir, t.dirs)
 	if t.files != nil {
-		t.fs.Files = t.files
+		t.fs.files = t.files
 	}
 
 	t.templateLoader = newTemplateLoaderMock()

--- a/internal/core/notebook.go
+++ b/internal/core/notebook.go
@@ -212,7 +212,7 @@ func (n *Notebook) RelPath(originalPath string) (string, error) {
 		return path, wrap(err)
 	}
 	if strings.HasPrefix(path, "..") {
-		return path, fmt.Errorf("%s: path is outside the notebook", originalPath)
+		return path, fmt.Errorf("%s: path is outside the notebook at %s", originalPath, n.Path)
 	}
 	if path == "." {
 		path = ""


### PR DESCRIPTION
* `--notebook-dir` does not change the working directory anymore, instead it sets manually the current notebook and disable auto-discovery. Use the new `--working-dir`/`-W` flag to run `zk` as if it was started from this path instead of the current working directory.
    * For convenience, `ZK_NOTEBOOK_DIR` behaves like setting a `--working-dir` fallback, instead of `--notebook-dir`. This way, paths will be relative to the root of the notebook.
    * A practical use case is to use `zk list -W .` when outside a notebook. This will list the notes in `ZK_NOTEBOOK_DIR` but print paths relative to the current directory, making them actionable from your terminal emulator.

This initial work will be useful to generate relative Markdown links by changing the reference point without manual `cd`.