### PR TITLE
Publish LSP diagnostics for dead links and wiki-link titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * [Editor integration through LSP](https://github.com/mickael-menu/zk/issues/22):
     * New code actions to create a note using the current selection as title.
     * Custom commands to [run `new` and `index` from your editor](docs/editors-integration.md#custom-commands).
+    * Diagnostics to [report dead links or wiki-link titles](docs/config-lsp.md).
 * Customize the format of `fzf`'s lines [with your own template](docs/tool-fzf.md).
     ```toml
     [tool]

--- a/docs/config-lsp.md
+++ b/docs/config-lsp.md
@@ -1,0 +1,27 @@
+# LSP configuration
+
+The `[lsp]` [configuration file](config.md) section provides settings to fine-tune the [LSP editors integration](editors-integration.md).
+
+## Diagnostics
+
+Use the `[lsp.diagnostics]` sub-section to configure how LSP diagnostics are reported to your editors. Each diagnostic setting can be:
+
+* An empty string or `none` to ignore this diagnostic.
+* `hint`, `info`, `warning` or `error` to enable and set the severity of the diagnostic.
+
+| Setting      | Default   | Description                                                               |
+|--------------|-----------|---------------------------------------------------------------------------|
+| `wiki-title` | `"none"`  | Report titles of wiki-links, which is useful if you use IDs for filenames |
+| `dead-link`  | `"error"` | Warn for dead links between notes                                         |
+
+## Complete example
+
+```toml
+[lsp]
+
+[lsp.diagnostics]
+# Report titles of wiki-links as hints.
+wiki-title = "hint"
+# Warn for dead links between notes.
+dead-link = "error"
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -5,11 +5,12 @@ Each [notebook](notebook.md) contains a configuration file used to customize you
 * `[note]` sets the [note creation rules](config-note.md)
 * `[extra]` contains free [user variables](config-extra.md) which can be expanded in templates
 * `[group]` defines [note groups](config-group.md) with custom rules
-* `[format]` configures the [note format settings](note-format.md), such as Markdown options.
+* `[format]` configures the [note format settings](note-format.md), such as Markdown options
 * `[tool]` customizes interaction with external programs such as:
     * [your default editor](tool-editor.md)
     * [your default pager](tool-pager.md)
     * [`fzf`](tool-fzf.md)
+* `[lsp]` setups the [Language Server Protocol settings](config-lsp.md) for [editors integration](editors-integration.md)
 * `[filter]` declares your [named filters](config-filter.md)
 * `[alias]` holds your [command aliases](config-alias.md)
 
@@ -104,5 +105,13 @@ recent = "zk edit --sort created- --created-after 'last two weeks' --interactive
 
 # Show a random note.
 lucky = "zk list --quiet --format full --sort random --limit 1"
-```
 
+# LSP (EDITOR INTEGRATION)
+[lsp]
+
+[lsp.diagnostics]
+# Report titles of wiki-links as hints.
+wiki-title = "hint"
+# Warn for dead links between notes.
+dead-link = "error"
+```

--- a/docs/editors-integration.md
+++ b/docs/editors-integration.md
@@ -14,7 +14,10 @@ There are several extensions available to integrate `zk` in your favorite editor
 * Preview the content of a note when hovering a link.
 * Navigate in your notes by following internal links.
 * Create a new note using the current selection as title.
+* Diagnostics for dead links and wiki-links titles.
 * [And more to come...](https://github.com/mickael-menu/zk/issues/22)
+  
+You can configure some of these features in your notebook's [configuration file](config-lsp.md).
 
 ### Editor LSP configurations
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -195,7 +195,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 	lines := d.GetLines()
 	for lineIndex, line := range lines {
 
-		appendLink := func(href string, start, end int) {
+		appendLink := func(href string, start, end int, hasTitle bool) {
 			if href == "" {
 				return
 			}
@@ -212,6 +212,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 						Character: protocol.UInteger(end),
 					},
 				},
+				HasTitle: hasTitle,
 			})
 		}
 
@@ -221,12 +222,13 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 			if decodedHref, err := url.PathUnescape(href); err == nil {
 				href = decodedHref
 			}
-			appendLink(href, match[0], match[1])
+			appendLink(href, match[0], match[1], true)
 		}
 
 		for _, match := range wikiLinkRegex.FindAllStringSubmatchIndex(line, -1) {
 			href := line[match[2]:match[3]]
-			appendLink(href, match[0], match[1])
+			hasTitle := match[4] != -1
+			appendLink(href, match[0], match[1], hasTitle)
 		}
 	}
 
@@ -236,4 +238,7 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 type documentLink struct {
 	Href  string
 	Range protocol.Range
+	// HasTitle indicates whether this link has a title information. For
+	// example [[filename]] doesn't but [[filename|title]] does.
+	HasTitle bool
 }

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -161,9 +161,9 @@ func globalConfigDir() string {
 
 // SetCurrentNotebook sets the first notebook found in the given search paths
 // as the current default one.
-func (c *Container) SetCurrentNotebook(searchDirs []Dirs) {
+func (c *Container) SetCurrentNotebook(searchDirs []Dirs) error {
 	if len(searchDirs) == 0 {
-		return
+		return nil
 	}
 
 	for _, dirs := range searchDirs {
@@ -176,9 +176,14 @@ func (c *Container) SetCurrentNotebook(searchDirs []Dirs) {
 			c.Config = c.currentNotebook.Config
 			// FIXME: Is there something to do to support multiple notebooks here?
 			os.Setenv("ZK_NOTEBOOK_DIR", c.currentNotebook.Path)
-			return
+		}
+		// Report the error only if it's not the "notebook not found" one.
+		var errNotFound core.ErrNotebookNotFound
+		if !errors.As(c.currentNotebookErr, &errNotFound) {
+			return c.currentNotebookErr
 		}
 	}
+	return nil
 }
 
 // SetWorkingDir resets the current working directory.

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -296,6 +296,22 @@ multiword-tags = false
 #fzf-preview = "bat -p --color always {-1}"
 
 
+# LSP
+#
+#   Configure basic editor integration for LSP-compatible editors.
+#   See https://github.com/mickael-menu/zk/blob/main/docs/editors-integration.md
+#
+[lsp]
+
+[lsp.diagnostics]
+# Each diagnostic can have for value: none, hint, info, warning, error
+
+# Report titles of wiki-links as hints.
+#wiki-title = "hint"
+# Warn for dead links between notes.
+dead-link = "error"
+
+
 # NAMED FILTERS
 #
 #    A named filter is a set of note filtering options used frequently together.

--- a/main.go
+++ b/main.go
@@ -68,7 +68,8 @@ func main() {
 	fatalIfError(err)
 	searchDirs, err := notebookSearchDirs(dirs)
 	fatalIfError(err)
-	container.SetCurrentNotebook(searchDirs)
+	err = container.SetCurrentNotebook(searchDirs)
+	fatalIfError(err)
 
 	// Run the alias or command.
 	if isAlias, err := runAlias(container, os.Args[1:]); isAlias {


### PR DESCRIPTION
### Added

* LSP diagnostics to [report dead links or wiki-link titles](docs/config-lsp.md).

<img width="421" alt="Screenshot 2021-05-16 at 21 44 05" src="https://user-images.githubusercontent.com/58686775/118411109-39bbf880-b693-11eb-99f8-fa69a7fe0ec2.png">

(Diagnostics are displayed as virtual text with Neovim 0.5's built-in LSP client)