### PR TITLE
remove go chmod command from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Make sure you have a working [Go installation](https://golang.org/), then clone 
 ```sh
 $ git clone https://github.com/mickael-menu/zk.git
 $ cd zk
-$ chmod a+x go
 ```
 
 #### On macOS


### PR DESCRIPTION
Now that the `go` script no longer exists in the repo, the chmod command isn't needed.

BTW zk is a great tool, I'm absolutely loving it. Thanks!