### PR TITLE
Add a new configuration option to ignore files when indexing notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to this project will be documented in this file.
     * `{{json .}}` serializes the full template context as a JSON object.
 * Use `--header` and `--footer` options with `zk list` to print arbitrary text at the start or end of the list.
 * Support for LSP references to browse the backlinks of the link under the caret (contributed by [@pstuifzand](https://github.com/mickael-menu/zk/pull/58)).
+* New [`note.ignore`](docs/config-note.md) configuration option to ignore files matching the given path globs when indexing notes.
+    ```yaml
+    [note]
+    ignore = [
+        "log-*.md"
+        "drafts/*"
+    ]
+    ```
 
 ### Fixed
 

--- a/docs/config-note.md
+++ b/docs/config-note.md
@@ -14,6 +14,8 @@ The `[note]` section from the [configuration file](config.md) is used to set the
 * `template` (string)
     * Path to the [template](template.md) used to generate the note content.
     * Either an absolute path, or relative to `.zk/templates/`.
+* `ignore` (list of strings)
+    * List of [path globs](https://en.wikipedia.org/wiki/Glob_\(programming\)) ignored during note indexing.
 * `id-charset` (string)
     * Characters set used to [generate random IDs](note-id.md).
     * You can use:

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -68,6 +68,16 @@ func (c Config) RootGroupConfig() GroupConfig {
 	}
 }
 
+// GroupConfigForPath returns the GroupConfig for the group matching the given
+// path relative to the notebook. Fallback on the root GroupConfig.
+func (c Config) GroupConfigForPath(path string) (GroupConfig, error) {
+	name, err := c.GroupNameForPath(path)
+	if err != nil {
+		return GroupConfig{}, err
+	}
+	return c.GroupConfigNamed(name)
+}
+
 // GroupConfigNamed returns the GroupConfig for the group with the given name.
 // An empty name matches the root GroupConfig.
 func (c Config) GroupConfigNamed(name string) (GroupConfig, error) {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -25,6 +25,7 @@ func TestParseDefaultConfig(t *testing.T) {
 			},
 			DefaultTitle: "Untitled",
 			Lang:         "en",
+			Ignore:       []string{},
 		},
 		Groups: make(map[string]GroupConfig),
 		Format: FormatConfig{
@@ -73,6 +74,7 @@ func TestParseComplete(t *testing.T) {
 		id-charset = "alphanum"
 		id-length = 4
 		id-case = "lower"
+		ignore = ["ignored", ".git"]
 
 		[format.markdown]
 		hashtags = false
@@ -112,6 +114,7 @@ func TestParseComplete(t *testing.T) {
 		id-charset = "letters"
 		id-length = 8
 		id-case = "mixed"
+		ignore = ["new-ignored"]
 		
 		[group.log.extra]
 		log-ext = "value"
@@ -140,6 +143,7 @@ func TestParseComplete(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
+			Ignore:       []string{"ignored", ".git"},
 		},
 		Groups: map[string]GroupConfig{
 			"log": {
@@ -155,6 +159,7 @@ func TestParseComplete(t *testing.T) {
 					},
 					Lang:         "de",
 					DefaultTitle: "Ohne Titel",
+					Ignore:       []string{"ignored", ".git", "new-ignored"},
 				},
 				Extra: map[string]string{
 					"hello":   "world",
@@ -175,6 +180,7 @@ func TestParseComplete(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
+					Ignore:       []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello": "world",
@@ -194,6 +200,7 @@ func TestParseComplete(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
+					Ignore:       []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello": "world",
@@ -249,6 +256,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 		id-charset = "letters"
 		id-length = 42
 		id-case = "upper"
+		ignore = ["ignored", ".git"]
 
 		[extra]
 		hello = "world"
@@ -281,6 +289,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
+			Ignore:       []string{"ignored", ".git"},
 		},
 		Groups: map[string]GroupConfig{
 			"log": {
@@ -296,6 +305,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
+					Ignore:       []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello":   "override",
@@ -316,6 +326,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
+					Ignore:       []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello": "world",
@@ -451,6 +462,33 @@ func TestParseLSPDiagnosticsSeverity(t *testing.T) {
 	assert.Err(t, err, "foobar: unknown LSP diagnostic severity - may be none, hint, info, warning or error")
 }
 
+func TestGroupConfigIgnoreGlobs(t *testing.T) {
+	// empty globs
+	config := GroupConfig{
+		Paths: []string{"path"},
+		Note:  NoteConfig{Ignore: []string{}},
+	}
+	assert.Equal(t, config.IgnoreGlobs(), []string{})
+
+	// empty paths
+	config = GroupConfig{
+		Paths: []string{},
+		Note: NoteConfig{
+			Ignore: []string{"ignored", ".git"},
+		},
+	}
+	assert.Equal(t, config.IgnoreGlobs(), []string{"ignored", ".git"})
+
+	// several paths
+	config = GroupConfig{
+		Paths: []string{"log", "drafts"},
+		Note: NoteConfig{
+			Ignore: []string{"ignored", "*.git"},
+		},
+	}
+	assert.Equal(t, config.IgnoreGlobs(), []string{"log/ignored", "log/*.git", "drafts/ignored", "drafts/*.git"})
+}
+
 func TestGroupConfigClone(t *testing.T) {
 	original := GroupConfig{
 		Paths: []string{"original"},
@@ -465,6 +503,7 @@ func TestGroupConfigClone(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
+			Ignore:       []string{"ignored", ".git"},
 		},
 		Extra: map[string]string{
 			"hello": "world",
@@ -484,6 +523,7 @@ func TestGroupConfigClone(t *testing.T) {
 	clone.Note.IDOptions.Case = CaseUpper
 	clone.Note.Lang = "de"
 	clone.Note.DefaultTitle = "Ohne Titel"
+	clone.Note.Ignore = []string{"other-ignored"}
 	clone.Extra["test"] = "modified"
 
 	// Check that we didn't modify the original
@@ -500,6 +540,7 @@ func TestGroupConfigClone(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
+			Ignore:       []string{"ignored", ".git"},
 		},
 		Extra: map[string]string{
 			"hello": "world",

--- a/internal/core/note_index.go
+++ b/internal/core/note_index.go
@@ -95,8 +95,17 @@ func (t *indexTask) execute(callback func(change paths.DiffChange)) (NoteIndexin
 
 	force := t.force || needsReindexing
 
-	// FIXME: Use Extension defined in each DirConfig.
-	source := paths.Walk(t.notebook.Path, t.notebook.Config.Note.Extension, t.logger)
+	shouldIgnorePath := func(path string) (bool, error) {
+		group, err := t.notebook.Config.GroupConfigForPath(path)
+		if err != nil {
+			return false, err
+		}
+
+		return filepath.Ext(path) != "."+group.Note.Extension, nil
+	}
+
+	source := paths.Walk(t.notebook.Path, t.logger, shouldIgnorePath)
+
 	target, err := t.index.IndexedPaths()
 	if err != nil {
 		return stats, wrap(err)

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -193,6 +193,12 @@ const defaultConfig = `# zk configuration file
 # If not an absolute path, it is relative to .zk/templates/
 template = "default.md"
 
+# Path globs ignored while indexing existing notes.
+#ignore = [
+#    "drafts/*",
+#	"log.md"
+#]
+
 # Configure random ID generation.
 
 # The charset used for random IDs. You can use:

--- a/internal/util/paths/walk_test.go
+++ b/internal/util/paths/walk_test.go
@@ -1,6 +1,7 @@
 package paths
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/mickael-menu/zk/internal/util"
@@ -11,8 +12,12 @@ import (
 func TestWalk(t *testing.T) {
 	var path = fixtures.Path("walk")
 
+	shouldIgnore := func(path string) (bool, error) {
+		return filepath.Ext(path) != ".md", nil
+	}
+
 	actual := make([]string, 0)
-	for m := range Walk(path, "md", &util.NullLogger) {
+	for m := range Walk(path, &util.NullLogger, shouldIgnore) {
 		assert.NotNil(t, m.Modified)
 		actual = append(actual, m.Path)
 	}


### PR DESCRIPTION
See discussion https://github.com/mickael-menu/zk/discussions/56

### Added

* New [`note.ignore`](docs/config-note.md) configuration option to ignore files matching the given path globs when indexing notes.
    ```yaml
    [note]
    ignore = [
        "log-*.md"
        "drafts/*"
    ]
    ```