### PR TITLE
Add "abs-path" to template-format

### DIFF
--- a/docs/template-format.md
+++ b/docs/template-format.md
@@ -5,7 +5,7 @@ The following variables are available in the templates used when formatting note
 | Variable      | Type     | Description                                                              |
 |---------------|----------|--------------------------------------------------------------------------|
 | `path`        | string   | File path to the note, relative to the current directory                 |
-| `full-path`   | string   | File path to the note, full path including the notebook directory        |
+| `abs-path`    | string   | File path to the note, absolute path including the notebook directory    |
 | `title`       | string   | Note title                                                               |
 | `link`        | string   | Markdown link to the note, relative to the current directory<sup>1</sup> |
 | `lead`        | string   | First paragraph extracted from the note content                          |

--- a/docs/template-format.md
+++ b/docs/template-format.md
@@ -5,6 +5,7 @@ The following variables are available in the templates used when formatting note
 | Variable      | Type     | Description                                                              |
 |---------------|----------|--------------------------------------------------------------------------|
 | `path`        | string   | File path to the note, relative to the current directory                 |
+| `full-path`   | string   | File path to the note, full path including the notebook directory        |
 | `title`       | string   | Note title                                                               |
 | `link`        | string   | Markdown link to the note, relative to the current directory<sup>1</sup> |
 | `lead`        | string   | First paragraph extracted from the note content                          |

--- a/internal/core/note_format.go
+++ b/internal/core/note_format.go
@@ -23,7 +23,10 @@ func newNoteFormatter(basePath string, template Template, linkFormatter LinkForm
 			return "", err
 		}
 
-		fullPath := filepath.Join(basePath, note.Path)
+		fullPath, err := fs.Abs(filepath.Join(basePath, note.Path))
+		if err != nil {
+			return "", err
+		}
 
 		snippets := make([]string, 0)
 		for _, snippet := range note.Snippets {

--- a/internal/core/note_format.go
+++ b/internal/core/note_format.go
@@ -23,7 +23,7 @@ func newNoteFormatter(basePath string, template Template, linkFormatter LinkForm
 			return "", err
 		}
 
-		fullPath, err := fs.Abs(filepath.Join(basePath, note.Path))
+		absPath, err := fs.Abs(filepath.Join(basePath, note.Path))
 		if err != nil {
 			return "", err
 		}
@@ -34,9 +34,9 @@ func newNoteFormatter(basePath string, template Template, linkFormatter LinkForm
 		}
 
 		return template.Render(noteFormatRenderContext{
-			Path:     path,
-			FullPath: fullPath,
-			Title:    note.Title,
+			Path:    path,
+			AbsPath: absPath,
+			Title:   note.Title,
 			Link: newLazyStringer(func() string {
 				link, _ := linkFormatter(path, note.Title)
 				return link
@@ -62,7 +62,7 @@ var noteTermRegex = regexp.MustCompile(`<zk:match>(.*?)</zk:match>`)
 // templates.
 type noteFormatRenderContext struct {
 	Path       string                 `json:"path"`
-	FullPath   string                 `json:"fullPath" handlebars:"full-path"`
+	AbsPath    string                 `json:"absPath" handlebars:"abs-path"`
 	Title      string                 `json:"title"`
 	Link       fmt.Stringer           `json:"link"`
 	Lead       string                 `json:"lead"`

--- a/internal/core/note_format.go
+++ b/internal/core/note_format.go
@@ -23,14 +23,17 @@ func newNoteFormatter(basePath string, template Template, linkFormatter LinkForm
 			return "", err
 		}
 
+		fullPath := filepath.Join(basePath, note.Path)
+
 		snippets := make([]string, 0)
 		for _, snippet := range note.Snippets {
 			snippets = append(snippets, noteTermRegex.ReplaceAllString(snippet, termRepl))
 		}
 
 		return template.Render(noteFormatRenderContext{
-			Path:  path,
-			Title: note.Title,
+			Path:     path,
+			FullPath: fullPath,
+			Title:    note.Title,
 			Link: newLazyStringer(func() string {
 				link, _ := linkFormatter(path, note.Title)
 				return link
@@ -56,6 +59,7 @@ var noteTermRegex = regexp.MustCompile(`<zk:match>(.*?)</zk:match>`)
 // templates.
 type noteFormatRenderContext struct {
 	Path       string                 `json:"path"`
+	FullPath   string                 `json:"fullPath" handlebars:"full-path"`
 	Title      string                 `json:"title"`
 	Link       fmt.Stringer           `json:"link"`
 	Lead       string                 `json:"lead"`

--- a/internal/core/note_format_test.go
+++ b/internal/core/note_format_test.go
@@ -71,6 +71,7 @@ func TestNewNoteFormatter(t *testing.T) {
 	assert.Equal(t, test.template.Contexts, []interface{}{
 		noteFormatRenderContext{
 			Path:       "note1",
+			FullPath:   "/notebook/note1",
 			Title:      "Note 1",
 			Link:       opt.NewString("[Note 1](note1)"),
 			Lead:       "Lead 1",
@@ -89,6 +90,7 @@ func TestNewNoteFormatter(t *testing.T) {
 		},
 		noteFormatRenderContext{
 			Path:       "dir/note2",
+			FullPath:   "/notebook/dir/note2",
 			Title:      "Note 2",
 			Link:       opt.NewString("[Note 2](dir/note2)"),
 			Lead:       "Lead 2",
@@ -106,7 +108,7 @@ func TestNewNoteFormatter(t *testing.T) {
 }
 
 func TestNoteFormatterMakesPathRelative(t *testing.T) {
-	test := func(basePath, currentPath, path string, expected string) {
+	test := func(basePath, currentPath, path string, expected, expectedFull string) {
 		test := formatTest{
 			rootDir:    basePath,
 			workingDir: currentPath,
@@ -121,6 +123,7 @@ func TestNoteFormatterMakesPathRelative(t *testing.T) {
 		assert.Equal(t, test.template.Contexts, []interface{}{
 			noteFormatRenderContext{
 				Path:     expected,
+				FullPath: expectedFull,
 				Link:     opt.NewString("[](" + paths.DropExt(expected) + ")"),
 				Snippets: []string{},
 			},
@@ -128,14 +131,14 @@ func TestNoteFormatterMakesPathRelative(t *testing.T) {
 	}
 
 	// Check that the path is relative to the current directory.
-	test("", "", "note.md", "note.md")
-	test("", "", "dir/note.md", "dir/note.md")
-	test("/abs/zk", "/abs/zk", "note.md", "note.md")
-	test("/abs/zk", "/abs/zk", "dir/note.md", "dir/note.md")
-	test("/abs/zk", "/abs/zk/dir", "note.md", "../note.md")
-	test("/abs/zk", "/abs/zk/dir", "dir/note.md", "note.md")
-	test("/abs/zk", "/abs", "note.md", "zk/note.md")
-	test("/abs/zk", "/abs", "dir/note.md", "zk/dir/note.md")
+	test("", "", "note.md", "note.md", "/notebook/note.md")
+	test("", "", "dir/note.md", "dir/note.md", "/notebook/dir/note.md")
+	test("/abs/zk", "/abs/zk", "note.md", "note.md", "/abs/zk/note.md")
+	test("/abs/zk", "/abs/zk", "dir/note.md", "dir/note.md", "/abs/zk/dir/note.md")
+	test("/abs/zk", "/abs/zk/dir", "note.md", "../note.md", "/abs/zk/note.md")
+	test("/abs/zk", "/abs/zk/dir", "dir/note.md", "note.md", "/abs/zk/dir/note.md")
+	test("/abs/zk", "/abs", "note.md", "zk/note.md", "/abs/zk/note.md")
+	test("/abs/zk", "/abs", "dir/note.md", "zk/dir/note.md", "/abs/zk/dir/note.md")
 }
 
 func TestNoteFormatterStylesSnippetTerm(t *testing.T) {
@@ -151,6 +154,7 @@ func TestNoteFormatterStylesSnippetTerm(t *testing.T) {
 		assert.Equal(t, test.template.Contexts, []interface{}{
 			noteFormatRenderContext{
 				Path:     ".",
+				FullPath: "/notebook",
 				Link:     opt.NewString("[]()"),
 				Snippets: []string{expected},
 			},

--- a/internal/core/note_format_test.go
+++ b/internal/core/note_format_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mickael-menu/zk/internal/util/opt"
 	"github.com/mickael-menu/zk/internal/util/paths"
+
 	"github.com/mickael-menu/zk/internal/util/test/assert"
 )
 
@@ -71,7 +72,7 @@ func TestNewNoteFormatter(t *testing.T) {
 	assert.Equal(t, test.template.Contexts, []interface{}{
 		noteFormatRenderContext{
 			Path:       "note1",
-			FullPath:   "/notebook/note1",
+			AbsPath:    "/notebook/note1",
 			Title:      "Note 1",
 			Link:       opt.NewString("[Note 1](note1)"),
 			Lead:       "Lead 1",
@@ -90,7 +91,7 @@ func TestNewNoteFormatter(t *testing.T) {
 		},
 		noteFormatRenderContext{
 			Path:       "dir/note2",
-			FullPath:   "/notebook/dir/note2",
+			AbsPath:    "/notebook/dir/note2",
 			Title:      "Note 2",
 			Link:       opt.NewString("[Note 2](dir/note2)"),
 			Lead:       "Lead 2",
@@ -123,7 +124,7 @@ func TestNoteFormatterMakesPathRelative(t *testing.T) {
 		assert.Equal(t, test.template.Contexts, []interface{}{
 			noteFormatRenderContext{
 				Path:     expected,
-				FullPath: expectedFull,
+				AbsPath:  expectedFull,
 				Link:     opt.NewString("[](" + paths.DropExt(expected) + ")"),
 				Snippets: []string{},
 			},
@@ -154,7 +155,7 @@ func TestNoteFormatterStylesSnippetTerm(t *testing.T) {
 		assert.Equal(t, test.template.Contexts, []interface{}{
 			noteFormatRenderContext{
 				Path:     ".",
-				FullPath: "/notebook",
+				AbsPath:  "/notebook",
 				Link:     opt.NewString("[]()"),
 				Snippets: []string{expected},
 			},


### PR DESCRIPTION
Adds a full path for the note to the list template to make integration easier.