### PR TITLE
Support pandoc filetype

### DIFF
--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -29,7 +29,7 @@ func newDocumentStore(fs core.FileStorage, logger util.Logger) *documentStore {
 
 func (s *documentStore) DidOpen(params protocol.DidOpenTextDocumentParams, notify glsp.NotifyFunc) (*document, error) {
 	langID := params.TextDocument.LanguageID
-	if langID != "markdown" && langID != "vimwiki" {
+	if langID != "markdown" && langID != "vimwiki" && langID != "pandoc" {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Enable compatibility with [vim-pandoc-syntax](https://github.com/vim-pandoc/vim-pandoc-syntax)