### PR TITLE
LSP references for the current note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 * Use the `{{abs-path}}` template variable when [formatting notes](docs/template-format.md) to print the absolute path to the note (contributed by [@pstuifzand](https://github.com/mickael-menu/zk/pull/60)).
 * Allow setting the `--working-dir` and `--notebook-dir` flags before the `zk` subcommand when using aliases, e.g. `zk -W ~/notes my-alias`.
+* Support for LSP references to browse the backlinks of the current note, if the caret is not over a link.
 
 ### Fixed
 

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -397,14 +397,21 @@ func NewServer(opts ServerOpts) *Server {
 			return nil, nil
 		}
 
-		link, err := doc.DocumentLinkAt(params.Position)
-		if link == nil || err != nil {
-			return nil, err
-		}
-
 		notebook, err := server.notebookOf(doc)
 		if err != nil {
 			return nil, err
+		}
+
+		link, err := doc.DocumentLinkAt(params.Position)
+		if err != nil {
+			return nil, err
+		}
+		if link == nil {
+			href, err := notebook.RelPath(doc.Path)
+			if err != nil {
+				return nil, err
+			}
+			link = &documentLink{Href: href}
 		}
 
 		target, err := server.noteForHref(link.Href, doc, notebook)


### PR DESCRIPTION
### Added

* Support for LSP references to browse the backlinks of the current note, if the caret is not over a link.