### PR TITLE
Do not exclude notes containing broken links from the index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 * UTF-8 handling in the LSP server.
+* [#78](https://github.com/mickael-menu/zk/issues/78) Do not exclude notes containing broken links from the index.
 
 
 ## 0.6.0

--- a/internal/core/note_index.go
+++ b/internal/core/note_index.go
@@ -200,7 +200,8 @@ func (t *indexTask) noteAt(path string) (Note, error) {
 			href := filepath.Join(filepath.Dir(absPath), link.Href)
 			link.Href, err = t.notebook.RelPath(href)
 			if err != nil {
-				return note, wrap(err)
+				t.logger.Err(err)
+				continue
 			}
 		}
 		note.Links = append(note.Links, link)


### PR DESCRIPTION
### Fixed

* [#78](https://github.com/mickael-menu/zk/issues/78) Do not exclude notes containing broken links from the index.