### PR TITLE
Customize LSP completion items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * New template variables `filename` and `filename-stem` when formatting notes (e.g. with `zk list --format`) and for the [`fzf-line`](docs/tool-fzf.md) config key.
+* Customize how LSP completion items appear in your editor when auto-completing links with the [`[lsp.completion]` configuration section](docs/config-lsp.md).
+    ```toml
+    [lsp.completion]
+    # Show the note title in the completion pop-up, or fallback on its path if empty.
+    note-label = "{{title-or-path}}"
+    # Filter out the completion pop-up using the note title or its path.
+    note-filter-text = "{{title}} {{path}}"
+    # Show the note filename without extension as detail.
+    note-detail = "{{filename-stem}}"
+    ```
 
 ### Fixed
 

--- a/docs/config-lsp.md
+++ b/docs/config-lsp.md
@@ -2,6 +2,32 @@
 
 The `[lsp]` [configuration file](config.md) section provides settings to fine-tune the [LSP editors integration](editors-integration.md).
 
+## Completion
+
+Customize how completion items appear in your editor when auto-completing links with the `[lsp.completion]` sub-section.
+
+| Setting            | Type       | Description                                                                |
+|--------------------|------------|----------------------------------------------------------------------------|
+| `note-label`       | `template` | Label displayed in the completion pop-up for each note                     |
+| `note-filter-text` | `template` | Text used as a source when filtering the completion pop-up with keystrokes |
+| `note-detail`      | `template` | Additional information about a completion item                             |
+
+Each key accepts a [template](template.md) with the following context:
+
+| Variable        | Type     | Description                                                        |
+|-----------------|----------|--------------------------------------------------------------------|
+| `filename`      | string   | Filename of the note, including its extension                      |
+| `filename-stem` | string   | Filename of the note without the file extension                    |
+| `path`          | string   | File path to the note, relative to the notebook root               |
+| `abs-path`      | string   | Absolute file path to the note                                     |
+| `rel-path`      | string   | File path to the note, relative to the current directory           |
+| `title`         | string   | Note title                                                         |
+| `title-or-path` | string   | Note title or path if empty                                        |
+| `metadata`      | map      | YAML frontmatter metadata, e.g. `metadata.description`<sup>1</sup> |
+
+1. YAML keys are normalized to lower case.
+
+
 ## Diagnostics
 
 Use the `[lsp.diagnostics]` sub-section to configure how LSP diagnostics are reported to your editors. Each diagnostic setting can be:
@@ -24,4 +50,12 @@ Use the `[lsp.diagnostics]` sub-section to configure how LSP diagnostics are rep
 wiki-title = "hint"
 # Warn for dead links between notes.
 dead-link = "error"
+
+[lsp.completion]
+# Show the note title in the completion pop-up, or fallback on its path if empty.
+note-label = "{{title-or-path}}"
+# Filter out the completion pop-up using the note title or its path.
+note-filter-text = "{{title}} {{path}}"
+# Show the note filename without extension as detail.
+note-detail = "{{filename-stem}}"
 ```

--- a/internal/adapter/lsp/completion.go
+++ b/internal/adapter/lsp/completion.go
@@ -1,0 +1,66 @@
+package lsp
+
+import (
+	"path/filepath"
+
+	"github.com/mickael-menu/zk/internal/core"
+	"github.com/mickael-menu/zk/internal/util/paths"
+)
+
+// completionTemplates holds templates to render the various elements of an LSP
+// completion item.
+type completionTemplates struct {
+	Label      core.Template
+	FilterText core.Template
+	Detail     core.Template
+}
+
+func newCompletionTemplates(loader core.TemplateLoader, templates core.LSPCompletionTemplates) (result completionTemplates, err error) {
+	if !templates.Label.IsNull() {
+		result.Label, err = loader.LoadTemplate(*templates.Label.Value)
+	}
+	if !templates.FilterText.IsNull() {
+		result.FilterText, err = loader.LoadTemplate(*templates.FilterText.Value)
+	}
+	if !templates.Detail.IsNull() {
+		result.Detail, err = loader.LoadTemplate(*templates.Detail.Value)
+	}
+
+	return
+}
+
+type completionItemRenderContext struct {
+	ID           int64
+	Filename     string
+	FilenameStem string `handlebars:"filename-stem"`
+	Path         string
+	AbsPath      string `handlebars:"abs-path"`
+	RelPath      string `handlebars:"rel-path"`
+	Title        string
+	TitleOrPath  string `handlebars:"title-or-path"`
+	Metadata     map[string]interface{}
+}
+
+func newCompletionItemRenderContext(note core.MinimalNote, notebookDir string, currentDir string) (completionItemRenderContext, error) {
+	absPath := filepath.Join(notebookDir, note.Path)
+	relPath, err := filepath.Rel(currentDir, absPath)
+	if err != nil {
+		return completionItemRenderContext{}, err
+	}
+
+	context := completionItemRenderContext{
+		ID:           int64(note.ID),
+		Filename:     filepath.Base(note.Path),
+		FilenameStem: paths.FilenameStem(note.Path),
+		Path:         note.Path,
+		AbsPath:      absPath,
+		RelPath:      relPath,
+		Title:        note.Title,
+		TitleOrPath:  note.Title,
+		Metadata:     note.Metadata,
+	}
+	if context.TitleOrPath == "" {
+		context.TitleOrPath = note.Path
+	}
+	return context, nil
+}

--- a/internal/cli/cmd/lsp.go
+++ b/internal/cli/cmd/lsp.go
@@ -13,12 +13,13 @@ type LSP struct {
 
 func (cmd *LSP) Run(container *cli.Container) error {
 	server := lsp.NewServer(lsp.ServerOpts{
-		Name:      "zk",
-		Version:   container.Version,
-		Logger:    container.Logger,
-		LogFile:   opt.NewNotEmptyString(cmd.Log),
-		Notebooks: container.Notebooks,
-		FS:        container.FS,
+		Name:           "zk",
+		Version:        container.Version,
+		Logger:         container.Logger,
+		LogFile:        opt.NewNotEmptyString(cmd.Log),
+		Notebooks:      container.Notebooks,
+		TemplateLoader: container.TemplateLoader,
+		FS:             container.FS,
 	})
 
 	return server.Run()

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -124,6 +124,11 @@ func TestParseComplete(t *testing.T) {
 
 		[group."without path"]
 		paths = []
+
+		[lsp.completion]
+		note-label = "notelabel"
+		note-filter-text = "notefiltertext"
+		note-detail = "notedetail"
 		
 		[lsp.diagnostics]
 		wiki-title = "hint"
@@ -225,6 +230,13 @@ func TestParseComplete(t *testing.T) {
 			FzfLine:    opt.NewString("{{title}}"),
 		},
 		LSP: LSPConfig{
+			Completion: LSPCompletionConfig{
+				Note: LSPCompletionTemplates{
+					Label:      opt.NewString("notelabel"),
+					FilterText: opt.NewString("notefiltertext"),
+					Detail:     opt.NewString("notedetail"),
+				},
+			},
 			Diagnostics: LSPDiagnosticConfig{
 				WikiTitle: LSPDiagnosticHint,
 				DeadLink:  LSPDiagnosticNone,
@@ -345,6 +357,13 @@ func TestParseMergesGroupConfig(t *testing.T) {
 			},
 		},
 		LSP: LSPConfig{
+			Completion: LSPCompletionConfig{
+				Note: LSPCompletionTemplates{
+					Label:      opt.NullString,
+					FilterText: opt.NullString,
+					Detail:     opt.NullString,
+				},
+			},
 			Diagnostics: LSPDiagnosticConfig{
 				WikiTitle: LSPDiagnosticNone,
 				DeadLink:  LSPDiagnosticError,

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -317,6 +317,16 @@ multiword-tags = false
 # Warn for dead links between notes.
 dead-link = "error"
 
+[lsp.completion]
+# Customize the completion pop-up of your LSP client.
+
+# Show the note title in the completion pop-up, or fallback on its path if empty.
+#note-label = "{{title-or-path}}"
+# Filter out the completion pop-up using the note title or its path.
+#note-filter-text = "{{title}} {{path}}"
+# Show the note filename without extension as detail.
+#note-detail = "{{filename-stem}}"
+
 
 # NAMED FILTERS
 #


### PR DESCRIPTION
### Added

* Customize how LSP completion items appear in your editor when auto-completing links with the [`[lsp.completion]` configuration section](docs/config-lsp.md).
    ```toml
    [lsp.completion]
    # Show the note title in the completion pop-up, or fallback on its path if empty.
    note-label = "{{title-or-path}}"
    # Filter out the completion pop-up using the note title or its path.
    note-filter-text = "{{title}} {{path}}"
    # Show the note filename without extension as detail.
    note-detail = "{{filename-stem}}"
    ```