### PR TITLE
Add `--dry-run` flag for `zk new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
     # Show the note filename without extension as detail.
     note-detail = "{{filename-stem}}"
     ```
+* New `--dry-run` flag for `zk new` which prints out the path and content of the generated note instead of saving it to the file system.
 
 ### Fixed
 

--- a/internal/core/note_parse.go
+++ b/internal/core/note_parse.go
@@ -44,15 +44,22 @@ type NoteContent struct {
 func (n *Notebook) ParseNoteAt(absPath string) (*Note, error) {
 	wrap := errors.Wrapper(absPath)
 
+	content, err := n.fs.Read(absPath)
+	if err != nil {
+		return nil, wrap(err)
+	}
+
+	return n.ParseNoteWithContent(absPath, content)
+}
+
+func (n *Notebook) ParseNoteWithContent(absPath string, content []byte) (*Note, error) {
+	wrap := errors.Wrapper(absPath)
+
 	relPath, err := n.RelPath(absPath)
 	if err != nil {
 		return nil, wrap(err)
 	}
 
-	content, err := n.fs.Read(absPath)
-	if err != nil {
-		return nil, wrap(err)
-	}
 	contentStr := string(content)
 	contentParts, err := n.parser.ParseNoteContent(contentStr)
 	if err != nil {
@@ -86,9 +93,7 @@ func (n *Notebook) ParseNoteAt(absPath string) (*Note, error) {
 	}
 
 	times, err := times.Stat(absPath)
-	if err != nil {
-		n.logger.Err(err)
-	} else {
+	if err == nil {
 		note.Modified = times.ModTime().UTC()
 		note.Created = creationDateFrom(note.Metadata, times)
 	}


### PR DESCRIPTION
Fix #93 

### Added

* New `--dry-run` flag for `zk new` which prints out the path and content of the generated note instead of saving it to the file system.