### PR TITLE
Fix indexing wiki links using partial paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 * [#89](https://github.com/mickael-menu/zk/issues/89) Calling `zk index` from outside the notebook (contributed by [@adamreese](https://github.com/mickael-menu/zk/pull/90)).
+* [#98](https://github.com/mickael-menu/zk/issues/98) Index wiki links using partial paths for `--linked-by` and `--link-to`.
 
 
 ## 0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 * [#89](https://github.com/mickael-menu/zk/issues/89) Calling `zk index` from outside the notebook (contributed by [@adamreese](https://github.com/mickael-menu/zk/pull/90)).
 * [#98](https://github.com/mickael-menu/zk/issues/98) Index wiki links using partial paths for `--linked-by` and `--link-to`.
+* [#98](https://github.com/mickael-menu/zk/issues/98) Ignore spaces around the pipe in wiki links for LSP diagnostics.
 
 
 ## 0.7.0

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -167,7 +167,7 @@ func (d *document) LookForward(pos protocol.Position, length int) string {
 	return line[charIdx:(charIdx + length)]
 }
 
-var wikiLinkRegex = regexp.MustCompile(`\[?\[\[(.+?)(?:\|(.+?))?\]\]`)
+var wikiLinkRegex = regexp.MustCompile(`\[?\[\[(.+?)(?: *\| *(.+?))?\]\]`)
 var markdownLinkRegex = regexp.MustCompile(`\[([^\]]+?[^\\])\]\((.+?[^\\])\)`)
 
 // DocumentLinkAt returns the internal or external link found in the document

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -732,7 +732,7 @@ func (s *Server) refreshDiagnosticsOfDocument(doc *document, notify glsp.NotifyF
 				severity = protocol.DiagnosticSeverity(diagConfig.DeadLink)
 				message = "not found"
 			} else {
-				if link.HasTitle || diagConfig.WikiTitle == core.LSPDiagnosticNone {
+				if diagConfig.WikiTitle == core.LSPDiagnosticNone {
 					continue
 				}
 				severity = protocol.DiagnosticSeverity(diagConfig.WikiTitle)

--- a/internal/adapter/markdown/markdown.go
+++ b/internal/adapter/markdown/markdown.go
@@ -226,6 +226,7 @@ func (p *Parser) parseLinks(root ast.Node, source []byte) ([]core.Link, error) {
 					links = append(links, core.Link{
 						Title:        string(link.Text(source)),
 						Href:         href,
+						Type:         core.LinkTypeMarkdown,
 						Rels:         core.LinkRels(strings.Fields(string(link.Title))...),
 						IsExternal:   strutil.IsURL(href),
 						Snippet:      snippet,
@@ -240,6 +241,7 @@ func (p *Parser) parseLinks(root ast.Node, source []byte) ([]core.Link, error) {
 					links = append(links, core.Link{
 						Title:        string(link.Label(source)),
 						Href:         href,
+						Type:         core.LinkTypeImplicit,
 						Rels:         []core.LinkRelation{},
 						IsExternal:   true,
 						Snippet:      snippet,
@@ -255,6 +257,7 @@ func (p *Parser) parseLinks(root ast.Node, source []byte) ([]core.Link, error) {
 					links = append(links, core.Link{
 						Title:        string(link.Text(source)),
 						Href:         href,
+						Type:         core.LinkTypeWikiLink,
 						Rels:         core.LinkRels(strings.Fields(string(link.Title))...),
 						IsExternal:   strutil.IsURL(href),
 						Snippet:      snippet,

--- a/internal/adapter/markdown/markdown_test.go
+++ b/internal/adapter/markdown/markdown_test.go
@@ -382,6 +382,7 @@ Neuron links with titles: [[trailing|Trailing link]]# #[[leading |  Leading link
 		{
 			Title:        "link",
 			Href:         "heading",
+			Type:         core.LinkTypeMarkdown,
 			Rels:         []core.LinkRelation{},
 			IsExternal:   false,
 			Snippet:      "Heading with a [link](heading)",
@@ -391,6 +392,7 @@ Neuron links with titles: [[trailing|Trailing link]]# #[[leading |  Leading link
 		{
 			Title:      "multiple links",
 			Href:       "stripped-formatting",
+			Type:       core.LinkTypeMarkdown,
 			Rels:       []core.LinkRelation{},
 			IsExternal: false,
 			Snippet: `Paragraph containing [multiple **links**](stripped-formatting), here's one [relative](../other).
@@ -401,6 +403,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:      "relative",
 			Href:       "../other",
+			Type:       core.LinkTypeMarkdown,
 			Rels:       []core.LinkRelation{},
 			IsExternal: false,
 			Snippet: `Paragraph containing [multiple **links**](stripped-formatting), here's one [relative](../other).
@@ -411,6 +414,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:      "one relation",
 			Href:       "one",
+			Type:       core.LinkTypeMarkdown,
 			Rels:       core.LinkRels("rel-1"),
 			IsExternal: false,
 			Snippet: `Paragraph containing [multiple **links**](stripped-formatting), here's one [relative](../other).
@@ -421,6 +425,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:      "several relations",
 			Href:       "several",
+			Type:       core.LinkTypeMarkdown,
 			Rels:       core.LinkRels("rel-1", "rel-2"),
 			IsExternal: false,
 			Snippet: `Paragraph containing [multiple **links**](stripped-formatting), here's one [relative](../other).
@@ -431,6 +436,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "https://inline-link.com",
 			Href:         "https://inline-link.com",
+			Type:         core.LinkTypeImplicit,
 			IsExternal:   true,
 			Rels:         []core.LinkRelation{},
 			Snippet:      "An https://inline-link.com and http://another-inline-link.com.",
@@ -440,6 +446,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "http://another-inline-link.com",
 			Href:         "http://another-inline-link.com",
+			Type:         core.LinkTypeImplicit,
 			IsExternal:   true,
 			Rels:         []core.LinkRelation{},
 			Snippet:      "An https://inline-link.com and http://another-inline-link.com.",
@@ -449,6 +456,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "Wiki link",
 			Href:         "Wiki link",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         []core.LinkRelation{},
 			Snippet:      "A [[Wiki link]] is surrounded by [[2-brackets | two brackets]].",
@@ -458,6 +466,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "two brackets",
 			Href:         "2-brackets",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         []core.LinkRelation{},
 			Snippet:      "A [[Wiki link]] is surrounded by [[2-brackets | two brackets]].",
@@ -467,6 +476,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "lien accentué",
 			Href:         "lien accentué",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         []core.LinkRelation{},
 			Snippet:      "[[lien accentué]]",
@@ -476,6 +486,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        `esca]]ped [chara\cters`,
 			Href:         `esca]]ped [chara\cters`,
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         []core.LinkRelation{},
 			Snippet:      `It can contain [[esca]\]ped \[chara\\cters]].`,
@@ -485,6 +496,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "Folgezettel link",
 			Href:         "Folgezettel link",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         core.LinkRels("down"),
 			Snippet:      "A [[[Folgezettel link]]] is surrounded by three brackets.",
@@ -494,6 +506,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "trailing hash",
 			Href:         "trailing hash",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         core.LinkRels("down"),
 			Snippet:      "Neuron also supports a [[trailing hash]]# for Folgezettel links.",
@@ -503,6 +516,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "leading hash",
 			Href:         "leading hash",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         core.LinkRels("up"),
 			Snippet:      "A #[[leading hash]] is used for #uplinks.",
@@ -512,6 +526,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "Trailing link",
 			Href:         "trailing",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         core.LinkRels("down"),
 			Snippet:      "Neuron links with titles: [[trailing|Trailing link]]# #[[leading |  Leading link]]",
@@ -521,6 +536,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "Leading link",
 			Href:         "leading",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         core.LinkRels("up"),
 			Snippet:      "Neuron links with titles: [[trailing|Trailing link]]# #[[leading |  Leading link]]",
@@ -530,6 +546,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "External links",
 			Href:         "http://example.com",
+			Type:         core.LinkTypeMarkdown,
 			Rels:         []core.LinkRelation{},
 			IsExternal:   true,
 			Snippet:      `[External links](http://example.com) are marked [as such](ftp://domain).`,
@@ -539,6 +556,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "as such",
 			Href:         "ftp://domain",
+			Type:         core.LinkTypeMarkdown,
 			Rels:         []core.LinkRelation{},
 			IsExternal:   true,
 			Snippet:      `[External links](http://example.com) are marked [as such](ftp://domain).`,
@@ -553,6 +571,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "foo%20bar",
 			Href:         "202110031652 foo bar",
+			Type:         core.LinkTypeMarkdown,
 			IsExternal:   false,
 			Rels:         []core.LinkRelation{},
 			Snippet:      "[foo%20bar](202110031652%20foo%20bar)",
@@ -564,6 +583,7 @@ A link can have [one relation](one "rel-1") or [several relations](several "rel-
 		{
 			Title:        "202110031652%20foo%20bar",
 			Href:         "202110031652%20foo%20bar",
+			Type:         core.LinkTypeWikiLink,
 			IsExternal:   false,
 			Rels:         []core.LinkRelation{},
 			Snippet:      "[[202110031652%20foo%20bar]]",

--- a/internal/adapter/sqlite/db.go
+++ b/internal/adapter/sqlite/db.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	"fmt"
 
 	sqlite "github.com/mattn/go-sqlite3"
 	"github.com/mickael-menu/zk/internal/core"
@@ -75,133 +76,142 @@ func (db *DB) migrate() error {
 			return err
 		}
 
+		migrations := []struct {
+			SQL             []string
+			NeedsReindexing bool
+		}{
+			{ // 1
+				SQL: []string{
+					// Notes
+					`CREATE TABLE IF NOT EXISTS notes (
+						id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+						path TEXT NOT NULL,
+						sortable_path TEXT NOT NULL,
+						title TEXT DEFAULT('') NOT NULL,
+						lead TEXT DEFAULT('') NOT NULL,
+						body TEXT DEFAULT('') NOT NULL,
+						raw_content TEXT DEFAULT('') NOT NULL,
+						word_count INTEGER DEFAULT(0) NOT NULL,
+						checksum TEXT NOT NULL,
+						created DATETIME DEFAULT(CURRENT_TIMESTAMP) NOT NULL,
+						modified DATETIME DEFAULT(CURRENT_TIMESTAMP) NOT NULL,
+						UNIQUE(path)
+					)`,
+					`CREATE INDEX IF NOT EXISTS index_notes_checksum ON notes (checksum)`,
+					`CREATE INDEX IF NOT EXISTS index_notes_path ON notes (path)`,
+
+					// Links
+					`CREATE TABLE IF NOT EXISTS links (
+						id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+						source_id INTEGER NOT NULL REFERENCES notes(id)
+							ON DELETE CASCADE,
+						target_id INTEGER REFERENCES notes(id)
+							ON DELETE SET NULL,
+						title TEXT DEFAULT('') NOT NULL,
+						href TEXT NOT NULL,
+						external INT DEFAULT(0) NOT NULL,
+						rels TEXT DEFAULT('') NOT NULL,
+						snippet TEXT DEFAULT('') NOT NULL
+					)`,
+					`CREATE INDEX IF NOT EXISTS index_links_source_id_target_id ON links (source_id, target_id)`,
+
+					// FTS index
+					`CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
+						path, title, body,
+						content = notes,
+						content_rowid = id,
+						tokenize = "porter unicode61 remove_diacritics 1 tokenchars '''&/'"
+					)`,
+					// Triggers to keep the FTS index up to date.
+					`CREATE TRIGGER IF NOT EXISTS trigger_notes_ai AFTER INSERT ON notes BEGIN
+						INSERT INTO notes_fts(rowid, path, title, body) VALUES (new.id, new.path, new.title, new.body);
+					END`,
+					`CREATE TRIGGER IF NOT EXISTS trigger_notes_ad AFTER DELETE ON notes BEGIN
+						INSERT INTO notes_fts(notes_fts, rowid, path, title, body) VALUES('delete', old.id, old.path, old.title, old.body);
+					END`,
+					`CREATE TRIGGER IF NOT EXISTS trigger_notes_au AFTER UPDATE ON notes BEGIN
+						INSERT INTO notes_fts(notes_fts, rowid, path, title, body) VALUES('delete', old.id, old.path, old.title, old.body);
+						INSERT INTO notes_fts(rowid, path, title, body) VALUES (new.id, new.path, new.title, new.body);
+					END`,
+				},
+			},
+
+			{ // 2
+				SQL: []string{
+					// Collections
+					`CREATE TABLE IF NOT EXISTS collections (
+						id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+						kind TEXT NO NULL,
+						name TEXT NOT NULL,
+						UNIQUE(kind, name)
+					)`,
+					`CREATE INDEX IF NOT EXISTS index_collections ON collections (kind, name)`,
+
+					// Note-Collection association
+					`CREATE TABLE IF NOT EXISTS notes_collections (
+						id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+						note_id INTEGER NOT NULL REFERENCES notes(id)
+							ON DELETE CASCADE,
+						collection_id INTEGER NOT NULL REFERENCES collections(id)
+							ON DELETE CASCADE
+					)`,
+					`CREATE INDEX IF NOT EXISTS index_notes_collections ON notes_collections (note_id, collection_id)`,
+
+					// View of notes with their associated metadata (e.g. tags), for simpler queries.
+					`CREATE VIEW notes_with_metadata AS
+					 SELECT n.*, GROUP_CONCAT(c.name, '` + "\x01" + `') AS tags
+					   FROM notes n
+					   LEFT JOIN notes_collections nc ON nc.note_id = n.id
+					   LEFT JOIN collections c ON nc.collection_id = c.id AND c.kind = '` + string(core.CollectionKindTag) + `'
+					  GROUP BY n.id`,
+				},
+			},
+
+			{ // 3
+				SQL: []string{
+					// Add a `metadata` column to `notes`
+					`ALTER TABLE notes ADD COLUMN metadata TEXT DEFAULT('{}') NOT NULL`,
+
+					// Add snippet's start and end offsets to `links`
+					`ALTER TABLE links ADD COLUMN snippet_start INTEGER DEFAULT(0) NOT NULL`,
+					`ALTER TABLE links ADD COLUMN snippet_end INTEGER DEFAULT(0) NOT NULL`,
+				},
+				NeedsReindexing: true,
+			},
+
+			{ // 4
+				SQL: []string{
+					// Metadata
+					`CREATE TABLE IF NOT EXISTS metadata (
+						key TEXT PRIMARY KEY NOT NULL,
+						value TEXT NO NULL
+					)`,
+				},
+			},
+
+			{ // 5
+				SQL: []string{
+					// Add a `type` column to `links`
+					`ALTER TABLE links ADD COLUMN type TEXT DEFAULT('') NOT NULL`,
+				},
+				NeedsReindexing: true,
+			},
+		}
+
 		needsReindexing := false
 
-		if version <= 0 {
-			err = tx.ExecStmts([]string{
-				// Notes
-				`CREATE TABLE IF NOT EXISTS notes (
-					id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-					path TEXT NOT NULL,
-					sortable_path TEXT NOT NULL,
-					title TEXT DEFAULT('') NOT NULL,
-					lead TEXT DEFAULT('') NOT NULL,
-					body TEXT DEFAULT('') NOT NULL,
-					raw_content TEXT DEFAULT('') NOT NULL,
-					word_count INTEGER DEFAULT(0) NOT NULL,
-					checksum TEXT NOT NULL,
-					created DATETIME DEFAULT(CURRENT_TIMESTAMP) NOT NULL,
-					modified DATETIME DEFAULT(CURRENT_TIMESTAMP) NOT NULL,
-					UNIQUE(path)
-				)`,
-				`CREATE INDEX IF NOT EXISTS index_notes_checksum ON notes (checksum)`,
-				`CREATE INDEX IF NOT EXISTS index_notes_path ON notes (path)`,
-
-				// Links
-				`CREATE TABLE IF NOT EXISTS links (
-					id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-					source_id INTEGER NOT NULL REFERENCES notes(id)
-						ON DELETE CASCADE,
-					target_id INTEGER REFERENCES notes(id)
-						ON DELETE SET NULL,
-					title TEXT DEFAULT('') NOT NULL,
-					href TEXT NOT NULL,
-					external INT DEFAULT(0) NOT NULL,
-					rels TEXT DEFAULT('') NOT NULL,
-					snippet TEXT DEFAULT('') NOT NULL
-				)`,
-				`CREATE INDEX IF NOT EXISTS index_links_source_id_target_id ON links (source_id, target_id)`,
-
-				// FTS index
-				`CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
-					path, title, body,
-					content = notes,
-					content_rowid = id,
-					tokenize = "porter unicode61 remove_diacritics 1 tokenchars '''&/'"
-				)`,
-				// Triggers to keep the FTS index up to date.
-				`CREATE TRIGGER IF NOT EXISTS trigger_notes_ai AFTER INSERT ON notes BEGIN
-					INSERT INTO notes_fts(rowid, path, title, body) VALUES (new.id, new.path, new.title, new.body);
-				END`,
-				`CREATE TRIGGER IF NOT EXISTS trigger_notes_ad AFTER DELETE ON notes BEGIN
-					INSERT INTO notes_fts(notes_fts, rowid, path, title, body) VALUES('delete', old.id, old.path, old.title, old.body);
-				END`,
-				`CREATE TRIGGER IF NOT EXISTS trigger_notes_au AFTER UPDATE ON notes BEGIN
-					INSERT INTO notes_fts(notes_fts, rowid, path, title, body) VALUES('delete', old.id, old.path, old.title, old.body);
-					INSERT INTO notes_fts(rowid, path, title, body) VALUES (new.id, new.path, new.title, new.body);
-				END`,
-				`PRAGMA user_version = 1`,
-			})
-			if err != nil {
-				return err
+		for i, migration := range migrations {
+			if version > i {
+				continue
 			}
-		}
 
-		if version <= 1 {
-			err = tx.ExecStmts([]string{
-				// Collections
-				`CREATE TABLE IF NOT EXISTS collections (
-					id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-					kind TEXT NO NULL,
-					name TEXT NOT NULL,
-					UNIQUE(kind, name)
-				)`,
-				`CREATE INDEX IF NOT EXISTS index_collections ON collections (kind, name)`,
-
-				// Note-Collection association
-				`CREATE TABLE IF NOT EXISTS notes_collections (
-					id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-					note_id INTEGER NOT NULL REFERENCES notes(id)
-						ON DELETE CASCADE,
-					collection_id INTEGER NOT NULL REFERENCES collections(id)
-						ON DELETE CASCADE
-				)`,
-				`CREATE INDEX IF NOT EXISTS index_notes_collections ON notes_collections (note_id, collection_id)`,
-
-				// View of notes with their associated metadata (e.g. tags), for simpler queries.
-				`CREATE VIEW notes_with_metadata AS
-				 SELECT n.*, GROUP_CONCAT(c.name, '` + "\x01" + `') AS tags
-				   FROM notes n
-				   LEFT JOIN notes_collections nc ON nc.note_id = n.id
-				   LEFT JOIN collections c ON nc.collection_id = c.id AND c.kind = '` + string(core.CollectionKindTag) + `'
-				  GROUP BY n.id`,
-
-				`PRAGMA user_version = 2`,
-			})
-			if err != nil {
-				return err
-			}
-		}
-
-		if version <= 2 {
-			err = tx.ExecStmts([]string{
-				// Add a `metadata` column to `notes`
-				`ALTER TABLE notes ADD COLUMN metadata TEXT DEFAULT('{}') NOT NULL`,
-
-				// Add snippet's start and end offsets to `links`
-				`ALTER TABLE links ADD COLUMN snippet_start INTEGER DEFAULT(0) NOT NULL`,
-				`ALTER TABLE links ADD COLUMN snippet_end INTEGER DEFAULT(0) NOT NULL`,
-
-				`PRAGMA user_version = 3`,
-			})
+			stmts := append(migration.SQL, fmt.Sprintf("PRAGMA user_version = %d", i+1))
+			err = tx.ExecStmts(stmts)
 			if err != nil {
 				return err
 			}
 
-			needsReindexing = true
-		}
-
-		if version <= 3 {
-			err = tx.ExecStmts([]string{
-				// Metadata
-				`CREATE TABLE IF NOT EXISTS metadata (
-					key TEXT PRIMARY KEY NOT NULL,
-					value TEXT NO NULL
-				)`,
-			})
-			if err != nil {
-				return err
-			}
+			needsReindexing = needsReindexing || migration.NeedsReindexing
 		}
 
 		if needsReindexing {

--- a/internal/adapter/sqlite/db_test.go
+++ b/internal/adapter/sqlite/db_test.go
@@ -27,7 +27,7 @@ func TestMigrateFrom0(t *testing.T) {
 		var version int
 		err := tx.QueryRow("PRAGMA user_version").Scan(&version)
 		assert.Nil(t, err)
-		assert.Equal(t, version, 3)
+		assert.Equal(t, version, 5)
 
 		_, err = tx.Exec(`
 			INSERT INTO notes (path, sortable_path, title, body, word_count, checksum)

--- a/internal/adapter/sqlite/note_dao.go
+++ b/internal/adapter/sqlite/note_dao.go
@@ -91,8 +91,8 @@ func NewNoteDAO(tx Transaction, logger util.Logger) *NoteDAO {
 
 		// Add a new link.
 		addLinkStmt: tx.PrepareLazy(`
-			INSERT INTO links (source_id, target_id, title, href, external, rels, snippet, snippet_start, snippet_end)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO links (source_id, target_id, title, href, type, external, rels, snippet, snippet_start, snippet_end)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`),
 
 		// Set links matching a given href and missing a target ID to the given
@@ -225,7 +225,7 @@ func (d *NoteDAO) addLinks(id core.NoteID, note core.Note) error {
 			return err
 		}
 
-		_, err = d.addLinkStmt.Exec(id, d.idToSql(targetId), link.Title, link.Href, link.IsExternal, joinLinkRels(link.Rels), link.Snippet, link.SnippetStart, link.SnippetEnd)
+		_, err = d.addLinkStmt.Exec(id, d.idToSql(targetId), link.Title, link.Href, link.Type, link.IsExternal, joinLinkRels(link.Rels), link.Snippet, link.SnippetStart, link.SnippetEnd)
 		if err != nil {
 			return err
 		}

--- a/internal/adapter/sqlite/note_dao.go
+++ b/internal/adapter/sqlite/note_dao.go
@@ -25,16 +25,15 @@ type NoteDAO struct {
 	logger util.Logger
 
 	// Prepared SQL statements
-	indexedStmt            *LazyStmt
-	addStmt                *LazyStmt
-	updateStmt             *LazyStmt
-	removeStmt             *LazyStmt
-	findIdByPathStmt       *LazyStmt
-	findIdByPathPrefixStmt *LazyStmt
-	findByIdStmt           *LazyStmt
-	addLinkStmt            *LazyStmt
-	setLinksTargetStmt     *LazyStmt
-	removeLinksStmt        *LazyStmt
+	indexedStmt        *LazyStmt
+	addStmt            *LazyStmt
+	updateStmt         *LazyStmt
+	removeStmt         *LazyStmt
+	findIdByPathStmt   *LazyStmt
+	findByIdStmt       *LazyStmt
+	addLinkStmt        *LazyStmt
+	setLinksTargetStmt *LazyStmt
+	removeLinksStmt    *LazyStmt
 }
 
 // NewNoteDAO creates a new instance of a DAO working on the given database
@@ -73,13 +72,6 @@ func NewNoteDAO(tx Transaction, logger util.Logger) *NoteDAO {
 		findIdByPathStmt: tx.PrepareLazy(`
 			SELECT id FROM notes
 			 WHERE path = ?
-		`),
-
-		// Find a note ID from a prefix of its path.
-		findIdByPathPrefixStmt: tx.PrepareLazy(`
-			SELECT id FROM notes
-			 WHERE path LIKE ? || '%'
-			 ORDER BY LENGTH(path) ASC
 		`),
 
 		// Find a note from its ID.
@@ -220,7 +212,9 @@ func (d *NoteDAO) metadataToJSON(note core.Note) string {
 // addLinks inserts all the outbound links of the given note.
 func (d *NoteDAO) addLinks(id core.NoteID, note core.Note) error {
 	for _, link := range note.Links {
-		targetId, err := d.findIdByPathPrefix(link.Href)
+		allowPartialMatch := (link.Type == core.LinkTypeWikiLink)
+		targetId, err := d.findIdByHref(link.Href, allowPartialMatch)
+
 		if err != nil {
 			return err
 		}
@@ -271,10 +265,10 @@ func (d *NoteDAO) findIdByPath(path string) (core.NoteID, error) {
 	return idForRow(row)
 }
 
-func (d *NoteDAO) findIdsByPathPrefixes(paths []string) ([]core.NoteID, error) {
+func (d *NoteDAO) findIdsByHrefs(hrefs []string, allowPartialMatch bool) ([]core.NoteID, error) {
 	ids := make([]core.NoteID, 0)
-	for _, path := range paths {
-		id, err := d.findIdByPathPrefix(path)
+	for _, href := range hrefs {
+		id, err := d.findIdByHref(href, allowPartialMatch)
 		if err != nil {
 			return ids, err
 		}
@@ -284,21 +278,31 @@ func (d *NoteDAO) findIdsByPathPrefixes(paths []string) ([]core.NoteID, error) {
 	}
 
 	if len(ids) == 0 {
-		return ids, fmt.Errorf("could not find notes at: " + strings.Join(paths, ", "))
+		return ids, fmt.Errorf("could not find notes at: " + strings.Join(hrefs, ", "))
 	}
 	return ids, nil
 }
 
-func (d *NoteDAO) findIdByPathPrefix(path string) (core.NoteID, error) {
-	// Remove any anchor at the end of the HREF, since it's most likely
-	// matching a sub-section in the note.
-	path = strings.SplitN(path, "#", 2)[0]
+func (d *NoteDAO) findIdByHref(href string, allowPartialMatch bool) (core.NoteID, error) {
+	if allowPartialMatch {
+		id, err := d.findIdByHref(href, false)
+		if id.IsValid() || err != nil {
+			return id, err
+		}
+	}
 
-	row, err := d.findIdByPathPrefixStmt.QueryRow(path)
+	opts := core.NewNoteFindOptsByHref(href, allowPartialMatch)
+
+	rows, err := d.findRows(opts, noteSelectionID)
 	if err != nil {
 		return 0, err
 	}
-	return idForRow(row)
+	defer rows.Close()
+
+	for rows.Next() {
+		return d.scanNoteID(rows)
+	}
+	return 0, nil
 }
 
 func idForRow(row *sql.Row) (core.NoteID, error) {
@@ -323,7 +327,7 @@ func (d *NoteDAO) FindMinimal(opts core.NoteFindOpts) ([]core.MinimalNote, error
 		return notes, err
 	}
 
-	rows, err := d.findRows(opts, true)
+	rows, err := d.findRows(opts, noteSelectionMinimal)
 	if err != nil {
 		return notes, err
 	}
@@ -343,33 +347,6 @@ func (d *NoteDAO) FindMinimal(opts core.NoteFindOpts) ([]core.MinimalNote, error
 	return notes, nil
 }
 
-func (d *NoteDAO) scanMinimalNote(row RowScanner) (*core.MinimalNote, error) {
-	var (
-		id                        int
-		path, title, metadataJSON string
-	)
-
-	err := row.Scan(&id, &path, &title, &metadataJSON)
-	switch {
-	case err == sql.ErrNoRows:
-		return nil, nil
-	case err != nil:
-		return nil, err
-	default:
-		metadata, err := unmarshalMetadata(metadataJSON)
-		if err != nil {
-			d.logger.Err(errors.Wrap(err, path))
-		}
-
-		return &core.MinimalNote{
-			ID:       core.NoteID(id),
-			Path:     path,
-			Title:    title,
-			Metadata: metadata,
-		}, nil
-	}
-}
-
 // Find returns all the notes matching the given criteria.
 func (d *NoteDAO) Find(opts core.NoteFindOpts) ([]core.ContextualNote, error) {
 	notes := make([]core.ContextualNote, 0)
@@ -379,7 +356,7 @@ func (d *NoteDAO) Find(opts core.NoteFindOpts) ([]core.ContextualNote, error) {
 		return notes, err
 	}
 
-	rows, err := d.findRows(opts, false)
+	rows, err := d.findRows(opts, noteSelectionFull)
 	if err != nil {
 		return notes, err
 	}
@@ -397,51 +374,6 @@ func (d *NoteDAO) Find(opts core.NoteFindOpts) ([]core.ContextualNote, error) {
 	}
 
 	return notes, nil
-}
-
-func (d *NoteDAO) scanNote(row RowScanner) (*core.ContextualNote, error) {
-	var (
-		id, wordCount                 int
-		title, lead, body, rawContent string
-		snippets, tags                sql.NullString
-		path, metadataJSON, checksum  string
-		created, modified             time.Time
-	)
-
-	err := row.Scan(
-		&id, &path, &title, &metadataJSON, &lead, &body, &rawContent,
-		&wordCount, &created, &modified, &checksum, &tags, &snippets,
-	)
-	switch {
-	case err == sql.ErrNoRows:
-		return nil, nil
-	case err != nil:
-		return nil, err
-	default:
-		metadata, err := unmarshalMetadata(metadataJSON)
-		if err != nil {
-			d.logger.Err(errors.Wrap(err, path))
-		}
-
-		return &core.ContextualNote{
-			Snippets: parseListFromNullString(snippets),
-			Note: core.Note{
-				ID:         core.NoteID(id),
-				Path:       path,
-				Title:      title,
-				Lead:       lead,
-				Body:       body,
-				RawContent: rawContent,
-				WordCount:  wordCount,
-				Links:      []core.Link{},
-				Tags:       parseListFromNullString(tags),
-				Metadata:   metadata,
-				Created:    created,
-				Modified:   modified,
-				Checksum:   checksum,
-			},
-		}, nil
-	}
 }
 
 // parseListFromNullString splits a 0-separated string.
@@ -465,7 +397,7 @@ func (d *NoteDAO) expandMentionsIntoMatch(opts core.NoteFindOpts) (core.NoteFind
 	}
 
 	// Find the IDs for the mentioned paths.
-	ids, err := d.findIdsByPathPrefixes(opts.Mention)
+	ids, err := d.findIdsByHrefs(opts.Mention, true /* allowPartialMatch */)
 	if err != nil {
 		return opts, err
 	}
@@ -507,7 +439,16 @@ func (d *NoteDAO) expandMentionsIntoMatch(opts core.NoteFindOpts) (core.NoteFind
 	return opts, nil
 }
 
-func (d *NoteDAO) findRows(opts core.NoteFindOpts, minimal bool) (*sql.Rows, error) {
+// noteSelection represents the amount of column selected with findRows.
+type noteSelection int
+
+const (
+	noteSelectionID noteSelection = iota + 1
+	noteSelectionMinimal
+	noteSelectionFull
+)
+
+func (d *NoteDAO) findRows(opts core.NoteFindOpts, selection noteSelection) (*sql.Rows, error) {
 	snippetCol := `n.lead`
 	joinClauses := []string{}
 	whereExprs := []string{}
@@ -518,8 +459,8 @@ func (d *NoteDAO) findRows(opts core.NoteFindOpts, minimal bool) (*sql.Rows, err
 	transitiveClosure := false
 	maxDistance := 0
 
-	setupLinkFilter := func(paths []string, direction int, negate, recursive bool) error {
-		ids, err := d.findIdsByPathPrefixes(paths)
+	setupLinkFilter := func(hrefs []string, direction int, negate, recursive bool) error {
+		ids, err := d.findIdsByHrefs(hrefs, true /* allowPartialMatch */)
 		if err != nil {
 			return err
 		}
@@ -673,7 +614,7 @@ WHERE collection_id IN (SELECT id FROM collections t WHERE kind = '%s' AND (%s))
 	}
 
 	if opts.MentionedBy != nil {
-		ids, err := d.findIdsByPathPrefixes(opts.MentionedBy)
+		ids, err := d.findIdsByHrefs(opts.MentionedBy, true /* allowPartialMatch */)
 		if err != nil {
 			return nil, err
 		}
@@ -783,9 +724,12 @@ WHERE collection_id IN (SELECT id FROM collections t WHERE kind = '%s' AND (%s))
 		query += "\n)\n"
 	}
 
-	query += "SELECT n.id, n.path, n.title, n.metadata"
-	if !minimal {
-		query += fmt.Sprintf(", n.lead, n.body, n.raw_content, n.word_count, n.created, n.modified, n.checksum, n.tags, %s AS snippet", snippetCol)
+	query += "SELECT n.id"
+	if selection != noteSelectionID {
+		query += ", n.path, n.title, n.metadata"
+		if selection != noteSelectionMinimal {
+			query += fmt.Sprintf(", n.lead, n.body, n.raw_content, n.word_count, n.created, n.modified, n.checksum, n.tags, %s AS snippet", snippetCol)
+		}
 	}
 
 	query += "\nFROM notes_with_metadata n\n"
@@ -812,6 +756,91 @@ WHERE collection_id IN (SELECT id FROM collections t WHERE kind = '%s' AND (%s))
 	// d.logger.Println(args)
 
 	return d.tx.Query(query, args...)
+}
+
+func (d *NoteDAO) scanNoteID(row RowScanner) (core.NoteID, error) {
+	var id int
+	err := row.Scan(&id)
+	switch {
+	case err == sql.ErrNoRows:
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return core.NoteID(id), nil
+	}
+}
+
+func (d *NoteDAO) scanMinimalNote(row RowScanner) (*core.MinimalNote, error) {
+	var (
+		id                        int
+		path, title, metadataJSON string
+	)
+
+	err := row.Scan(&id, &path, &title, &metadataJSON)
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, nil
+	case err != nil:
+		return nil, err
+	default:
+		metadata, err := unmarshalMetadata(metadataJSON)
+		if err != nil {
+			d.logger.Err(errors.Wrap(err, path))
+		}
+
+		return &core.MinimalNote{
+			ID:       core.NoteID(id),
+			Path:     path,
+			Title:    title,
+			Metadata: metadata,
+		}, nil
+	}
+}
+
+func (d *NoteDAO) scanNote(row RowScanner) (*core.ContextualNote, error) {
+	var (
+		id, wordCount                 int
+		title, lead, body, rawContent string
+		snippets, tags                sql.NullString
+		path, metadataJSON, checksum  string
+		created, modified             time.Time
+	)
+
+	err := row.Scan(
+		&id, &path, &title, &metadataJSON, &lead, &body, &rawContent,
+		&wordCount, &created, &modified, &checksum, &tags, &snippets,
+	)
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, nil
+	case err != nil:
+		return nil, err
+	default:
+		metadata, err := unmarshalMetadata(metadataJSON)
+		if err != nil {
+			d.logger.Err(errors.Wrap(err, path))
+		}
+
+		return &core.ContextualNote{
+			Snippets: parseListFromNullString(snippets),
+			Note: core.Note{
+				ID:         core.NoteID(id),
+				Path:       path,
+				Title:      title,
+				Lead:       lead,
+				Body:       body,
+				RawContent: rawContent,
+				WordCount:  wordCount,
+				Links:      []core.Link{},
+				Tags:       parseListFromNullString(tags),
+				Metadata:   metadata,
+				Created:    created,
+				Modified:   modified,
+				Checksum:   checksum,
+			},
+		}, nil
+	}
 }
 
 func orderTerm(sorter core.NoteSorter) string {

--- a/internal/adapter/sqlite/note_dao_test.go
+++ b/internal/adapter/sqlite/note_dao_test.go
@@ -315,6 +315,7 @@ func TestNoteDAOUpdateWithLinks(t *testing.T) {
 				{
 					Title:      "A new link",
 					Href:       "index",
+					Type:       core.LinkTypeWikiLink,
 					IsExternal: false,
 					Rels:       core.LinkRels("rel"),
 					Snippet:    "[[A new link]]",
@@ -322,6 +323,7 @@ func TestNoteDAOUpdateWithLinks(t *testing.T) {
 				{
 					Title:      "An external link",
 					Href:       "https://domain.com",
+					Type:       core.LinkTypeMarkdown,
 					IsExternal: true,
 					Snippet:    "[[An external link]]",
 				},
@@ -336,6 +338,7 @@ func TestNoteDAOUpdateWithLinks(t *testing.T) {
 				TargetId: idPointer(3),
 				Title:    "A new link",
 				Href:     "index",
+				Type:     "wiki-link",
 				Rels:     "\x01rel\x01",
 				Snippet:  "[[A new link]]",
 			},
@@ -344,6 +347,7 @@ func TestNoteDAOUpdateWithLinks(t *testing.T) {
 				TargetId:   nil,
 				Title:      "An external link",
 				Href:       "https://domain.com",
+				Type:       "markdown",
 				IsExternal: true,
 				Snippet:    "[[An external link]]",
 			},
@@ -1157,18 +1161,18 @@ func queryNoteRow(tx Transaction, where string) (noteRow, error) {
 }
 
 type linkRow struct {
-	SourceId                   core.NoteID
-	TargetId                   *core.NoteID
-	Href, Title, Rels, Snippet string
-	SnippetStart, SnippetEnd   int
-	IsExternal                 bool
+	SourceId                         core.NoteID
+	TargetId                         *core.NoteID
+	Href, Type, Title, Rels, Snippet string
+	SnippetStart, SnippetEnd         int
+	IsExternal                       bool
 }
 
 func queryLinkRows(t *testing.T, tx Transaction, where string) []linkRow {
 	links := make([]linkRow, 0)
 
 	rows, err := tx.Query(fmt.Sprintf(`
-		SELECT source_id, target_id, title, href, external, rels, snippet, snippet_start, snippet_end
+		SELECT source_id, target_id, title, href, type, external, rels, snippet, snippet_start, snippet_end
 		  FROM links
 		 WHERE %v
 		 ORDER BY id
@@ -1179,7 +1183,7 @@ func queryLinkRows(t *testing.T, tx Transaction, where string) []linkRow {
 		var row linkRow
 		var sourceId int64
 		var targetId *int64
-		err = rows.Scan(&sourceId, &targetId, &row.Title, &row.Href, &row.IsExternal, &row.Rels, &row.Snippet, &row.SnippetStart, &row.SnippetEnd)
+		err = rows.Scan(&sourceId, &targetId, &row.Title, &row.Href, &row.Type, &row.IsExternal, &row.Rels, &row.Snippet, &row.SnippetStart, &row.SnippetEnd)
 		assert.Nil(t, err)
 		row.SourceId = core.NoteID(sourceId)
 		if targetId != nil {

--- a/internal/adapter/sqlite/testdata/sample.db
+++ b/internal/adapter/sqlite/testdata/sample.db
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b7ba9b3ab5296c19e6a7a61ee4ca43116840ef956a1491c670bd7591abbd313
+oid sha256:ac4ece96d790615233beec6e47eb094200eba7178d65f4803a8df6232b9719c4
 size 86016

--- a/internal/core/link.go
+++ b/internal/core/link.go
@@ -6,6 +6,8 @@ type Link struct {
 	Title string
 	// Destination URI of the link.
 	Href string
+	// Type of link, e.g. wiki link.
+	Type LinkType
 	// Indicates whether the target is a remote (e.g. HTTP) resource.
 	IsExternal bool
 	// Relationships between the note and the linked target.
@@ -17,6 +19,15 @@ type Link struct {
 	// End byte offset of the snippet in the note content.
 	SnippetEnd int
 }
+
+// LinkType represents the kind of link, e.g. wiki link.
+type LinkType string
+
+const (
+	LinkTypeImplicit LinkType = "implicit" // No markup, e.g. http://example.com
+	LinkTypeMarkdown LinkType = "markdown"
+	LinkTypeWikiLink LinkType = "wiki-link"
+)
 
 // LinkRelation defines the relationship between a link's source and target.
 type LinkRelation string

--- a/internal/core/notebook.go
+++ b/internal/core/notebook.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/mickael-menu/zk/internal/util"
 	"github.com/mickael-menu/zk/internal/util/errors"
-	"github.com/mickael-menu/zk/internal/util/icu"
 	"github.com/mickael-menu/zk/internal/util/opt"
 	"github.com/mickael-menu/zk/internal/util/paths"
 	"github.com/schollz/progressbar/v3"
@@ -227,21 +226,7 @@ func (n *Notebook) FindMinimalNote(opts NoteFindOpts) (*MinimalNote, error) {
 // FindByHref retrieves the first note matching the given link href.
 // If allowPartialMatch is true, the href can match any unique sub portion of a note path.
 func (n *Notebook) FindByHref(href string, allowPartialMatch bool) (*MinimalNote, error) {
-	// Remove any anchor at the end of the HREF, since it's most likely
-	// matching a sub-section in the note.
-	href = strings.SplitN(href, "#", 2)[0]
-
-	if allowPartialMatch {
-		href = "(.*)" + icu.EscapePattern(href) + "(.*)"
-	}
-
-	return n.FindMinimalNote(NoteFindOpts{
-		IncludePaths:      []string{href},
-		EnablePathRegexes: allowPartialMatch,
-		// To find the best match possible, we sort by path length.
-		// See https://github.com/mickael-menu/zk/issues/23
-		Sorters: []NoteSorter{{Field: NoteSortPathLength, Ascending: true}},
-	})
+	return n.FindMinimalNote(NewNoteFindOptsByHref(href, allowPartialMatch))
 }
 
 // FindMatching retrieves the first note matching the given search terms.


### PR DESCRIPTION
Fix #98 

### Fixed

* [#98](https://github.com/mickael-menu/zk/issues/98) Index wiki links using partial paths for `--linked-by` and `--link-to`.
* [#98](https://github.com/mickael-menu/zk/issues/98) Ignore spaces around the pipe in wiki links for LSP diagnostics.