### PR TITLE
Filter through the note frontmatter with `--interactive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
     ```
 * New `--dry-run` flag for `zk new` which prints out the path and content of the generated note instead of saving it to the file system.
 * New `--verbose` flag for `zk index` which prints detailed information about the indexing process.
+* You can now filter through the [YAML frontmatter](docs/note-frontmatter.md) with `zk list --interactive`.
 
 ### Fixed
 

--- a/docs/tool-fzf.md
+++ b/docs/tool-fzf.md
@@ -28,7 +28,7 @@ fzf-preview = "zk list --quiet --format full --limit 1 {-1}"
 
 With the `fzf-line` setting property, you can provide your own [template](template.md) to customize the format of each `fzf` line. The lines are used by `fzf` for the fuzzy matching, so if you want to search in the full note content, do not forget to add `{{body}}` in your custom template.
 
-The default line template is `{{style "title" title-or-path}} {{style "understate" body}}`.
+The default line template is `{{style "title" title-or-path}} {{style "understate" body}} {{style "understate" (json metadata)}}`.
 
 Here's an example using different colors and showing the list of tags as #hashtags:
 

--- a/internal/adapter/fzf/note_filter.go
+++ b/internal/adapter/fzf/note_filter.go
@@ -156,7 +156,7 @@ func (f *NoteFilter) Apply(notes []core.ContextualNote) ([]core.ContextualNote, 
 	return selectedNotes, nil
 }
 
-var defaultLineTemplate = `{{style "title" title-or-path}} {{style "understate" body}}`
+var defaultLineTemplate = `{{style "title" title-or-path}} {{style "understate" body}} {{style "understate" (json metadata)}}`
 
 type lineRenderContext struct {
 	Filename     string

--- a/internal/adapter/handlebars/handlebars_test.go
+++ b/internal/adapter/handlebars/handlebars_test.go
@@ -238,7 +238,7 @@ func TestDateHelper(t *testing.T) {
 	testString(t, "{{date now 'timestamp'}}", context, "200911172034")
 	testString(t, "{{date now 'timestamp-unix'}}", context, "1258490098")
 	testString(t, "{{date now 'cust: %Y-%m'}}", context, "cust: 2009-11")
-	testString(t, "{{date now 'elapsed'}}", context, "12 years ago")
+	testString(t, "{{date now 'elapsed'}}", context, "13 years ago")
 }
 
 func TestShellHelper(t *testing.T) {


### PR DESCRIPTION
### Added

* You can now filter through the [YAML frontmatter](docs/note-frontmatter.md) with `zk list --interactive`.

---

* Fix #109 