### PR TITLE
Don't match all notes when `--link-to` or `--linked-by` have no match

### DIFF
--- a/internal/adapter/sqlite/note_dao.go
+++ b/internal/adapter/sqlite/note_dao.go
@@ -454,7 +454,7 @@ func (d *NoteDAO) findRows(opts core.NoteFindOpts, selection noteSelection) (*sq
 			return err
 		}
 		if len(ids) == 0 {
-			return nil
+			return fmt.Errorf("could not find notes at: " + strings.Join(hrefs, ", "))
 		}
 		idsList := "(" + joinNoteIDs(ids, ",") + ")"
 

--- a/internal/adapter/sqlite/note_dao_test.go
+++ b/internal/adapter/sqlite/note_dao_test.go
@@ -633,6 +633,16 @@ func TestNoteDAOFindUnlinkedMentions(t *testing.T) {
 	)
 }
 
+func TestNoteDAOFindMentionUnknown(t *testing.T) {
+	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
+		opts := core.NoteFindOpts{
+			Mention: []string{"will-not-be-found"},
+		}
+		_, err := dao.Find(opts)
+		assert.Err(t, err, "could not find notes at: will-not-be-found")
+	})
+}
+
 func TestNoteDAOFindMentionedBy(t *testing.T) {
 	testNoteDAOFind(t,
 		core.NoteFindOpts{MentionedBy: []string{"ref/test/b.md", "log/2021-01-04.md"}},
@@ -695,6 +705,16 @@ func TestNoteDAOFindUnlinkedMentionedBy(t *testing.T) {
 		},
 		[]string{"log/2021-01-03.md"},
 	)
+}
+
+func TestNoteDAOFindMentionedByUnknown(t *testing.T) {
+	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
+		opts := core.NoteFindOpts{
+			MentionedBy: []string{"will-not-be-found"},
+		}
+		_, err := dao.Find(opts)
+		assert.Err(t, err, "could not find notes at: will-not-be-found")
+	})
 }
 
 func TestNoteDAOFindLinkedBy(t *testing.T) {
@@ -792,6 +812,18 @@ func TestNoteDAOFindLinkedByWithSnippets(t *testing.T) {
 	)
 }
 
+func TestNoteDAOFindLinkedByUnknown(t *testing.T) {
+	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
+		opts := core.NoteFindOpts{
+			LinkedBy: &core.LinkFilter{
+				Hrefs: []string{"will-not-be-found"},
+			},
+		}
+		_, err := dao.Find(opts)
+		assert.Err(t, err, "could not find notes at: will-not-be-found")
+	})
+}
+
 func TestNoteDAOFindNotLinkedBy(t *testing.T) {
 	testNoteDAOFindPaths(t,
 		core.NoteFindOpts{
@@ -852,6 +884,18 @@ func TestNoteDAOFindNotLinkTo(t *testing.T) {
 		},
 		[]string{"ref/test/ref.md", "ref/test/b.md", "ref/test/a.md", "log/2021-02-04.md", "index.md", "log/2021-01-04.md"},
 	)
+}
+
+func TestNoteDAOFindLinkToUnknown(t *testing.T) {
+	testNoteDAO(t, func(tx Transaction, dao *NoteDAO) {
+		opts := core.NoteFindOpts{
+			LinkTo: &core.LinkFilter{
+				Hrefs: []string{"will-not-be-found"},
+			},
+		}
+		_, err := dao.Find(opts)
+		assert.Err(t, err, "could not find notes at: will-not-be-found")
+	})
 }
 
 func TestNoteDAOFindRelated(t *testing.T) {


### PR DESCRIPTION
If `--link-to` didn't match any note, then it's as if there was no filter anymore. Now an error is returned instead.