### PR TITLE
Fix infinite loop when parsing a single-character hashtag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * New LSP commands:
     * [`zk.list`](docs/editors-integration.md#zklist) to search for notes.
     * [`zk.tag.list`](docs/editors-integration.md#zktaglist) to retrieve the list of tags.
+* `--debug` mode which prints a stacktrace on `SIGINT`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 * [#111](https://github.com/mickael-menu/zk/issues/111) Filenames take precedence over folders when matching a sub-path with wiki links.
+* [#118](https://github.com/mickael-menu/zk/issues/118) Fix infinite loop when parsing a single-character hashtag.
 
 
 ## 0.8.0

--- a/internal/adapter/markdown/extensions/tag.go
+++ b/internal/adapter/markdown/extensions/tag.go
@@ -106,7 +106,11 @@ func (p *hashtagParser) Parse(parent ast.Node, block text.Reader, pc parser.Cont
 		}
 	}
 
-	for i, char := range string(line[1:]) {
+	for i, char := range string(line) {
+		if i == 0 {
+			// Skip the first character, as it is #
+			continue
+		}
 		if parsingMultiWordTag {
 			multiWordTagEndPos = i
 		} else {

--- a/internal/adapter/markdown/markdown_test.go
+++ b/internal/adapter/markdown/markdown_test.go
@@ -188,6 +188,10 @@ func TestParseHashtags(t *testing.T) {
 	test("##invalid also#invalid", []string{})
 	// Bear's multi multi-word tags are disabled
 	test("#multi word# end", []string{"multi"})
+
+	// Single character
+	// See https://github.com/mickael-menu/zk/issues/118
+	test("#a", []string{"a"})
 }
 
 func TestParseWordtags(t *testing.T) {


### PR DESCRIPTION
### Added

* `--debug` mode which prints a stacktrace on `SIGINT`.

### Fixed

* [#118](https://github.com/mickael-menu/zk/issues/118) Fix infinite loop when parsing a single-character hashtag.

---

* Fix #118 