### PR TITLE
Take into account `--no-input` with `zk init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 * [#111](https://github.com/mickael-menu/zk/issues/111) Filenames take precedence over folders when matching a sub-path with wiki links.
 * [#118](https://github.com/mickael-menu/zk/issues/118) Fix infinite loop when parsing a single-character hashtag.
+* [#121](https://github.com/mickael-menu/zk/issues/121) Take into account the `--no-input` flag with `zk init`.
 
 
 ## 0.8.0

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -17,7 +17,7 @@ type Init struct {
 }
 
 func (cmd *Init) Run(container *cli.Container) error {
-	opts, err := startInitWizard()
+	opts, err := newInitOpts(container)
 	if err != nil {
 		if err == terminal.InterruptErr {
 			return nil
@@ -44,6 +44,14 @@ func (cmd *Init) Run(container *cli.Container) error {
 
 	fmt.Printf("Initialized a notebook in %v\n", path)
 	return nil
+}
+
+func newInitOpts(container *cli.Container) (core.InitOpts, error) {
+	if container.Terminal.NoInput {
+		return core.NewDefaultInitOpts(), nil
+	} else {
+		return startInitWizard()
+	}
 }
 
 func startInitWizard() (core.InitOpts, error) {

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -102,6 +102,16 @@ type InitOpts struct {
 	MultiwordTags bool
 }
 
+// NewDefaultInitOpts creates a new instance of InitOpts with the default values.
+func NewDefaultInitOpts() InitOpts {
+	return InitOpts{
+		WikiLinks:     true,
+		Hashtags:      true,
+		ColonTags:     false,
+		MultiwordTags: false,
+	}
+}
+
 // Init creates a new notebook at the given file path.
 func (ns *NotebookStore) Init(path string, options InitOpts) (*Notebook, error) {
 	wrap := errors.Wrapper("init")


### PR DESCRIPTION
### Fixed

 * [#121](https://github.com/mickael-menu/zk/issues/121) Take into account the `--no-input` flag with `zk init`.

---

* Fix #121 