### PR TITLE
Support RFC 3339 dates with the time flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 * [#111](https://github.com/mickael-menu/zk/issues/111) Filenames take precedence over folders when matching a sub-path with wiki links.
 * [#118](https://github.com/mickael-menu/zk/issues/118) Fix infinite loop when parsing a single-character hashtag.
 * [#121](https://github.com/mickael-menu/zk/issues/121) Take into account the `--no-input` flag with `zk init`.
+* [#120](https://github.com/mickael-menu/zk/discussions/120) Support RFC 3339 dates with the time flags (e.g. `--created-before`).
 
 
 ## 0.8.0

--- a/internal/util/date/date.go
+++ b/internal/util/date/date.go
@@ -44,5 +44,8 @@ func TimeFromNatural(date string) (time.Time, error) {
 	if i, err := strconv.ParseInt(date, 10, 0); err == nil && i >= 1000 && i < 5000 {
 		return time.Date(int(i), time.January, 0, 0, 0, 0, 0, time.UTC), nil
 	}
+	if t, err := time.Parse(time.RFC3339, date); err == nil {
+		return t, nil
+	}
 	return naturaldate.Parse(date, time.Now().UTC(), naturaldate.WithDirection(naturaldate.Past))
 }


### PR DESCRIPTION
### Fixed

 * [#120](https://github.com/mickael-menu/zk/discussions/120) Support RFC 3339 dates with the time flags (e.g. `--created-before`).
