### PR TITLE
Fix embedded image links shown as not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+* [#126](https://github.com/mickael-menu/zk/issues/126) Embedded image links shown as not found.
+
 
 ## 0.9.0
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -218,6 +218,11 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 		}
 
 		for _, match := range markdownLinkRegex.FindAllStringSubmatchIndex(line, -1) {
+			// Ignore embedded image, e.g. ![title](href.png)
+			if match[0] > 0 && line[match[0]-1] == '!' {
+				continue
+			}
+
 			href := line[match[4]:match[5]]
 			// Valid Markdown links are percent-encoded.
 			if decodedHref, err := url.PathUnescape(href); err == nil {


### PR DESCRIPTION
### Fixed

* [#126](https://github.com/mickael-menu/zk/issues/126) Embedded image links shown as not found.

---

* Fix #126 