### PR TITLE
Add support for `ZK_SHELL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 * [#144](https://github.com/mickael-menu/zk/issues/144) LSP auto-completion of YAML frontmatter tags.
 * [zk-nvim#26](https://github.com/mickael-menu/zk-nvim/issues/26) The LSP server doesn't use `additionalTextEdits` anymore to remove the trigger characters when completing links.
     * You can customize the default behavior with the [`use-additional-text-edits` configuration key](docs/config-lsp.md).
+* [#163](https://github.com/mickael-menu/zk/issues/163) Use the `ZK_SHELL` environment variable to override the shell for `zk` only.
 
 ### Fixed
 

--- a/internal/util/exec/exec_unix.go
+++ b/internal/util/exec/exec_unix.go
@@ -3,16 +3,18 @@
 package exec
 
 import (
-	"os"
 	"os/exec"
+
+	osutil "github.com/mickael-menu/zk/internal/util/os"
 )
 
 // CommandFromString returns a Cmd running the given command with $SHELL.
 func CommandFromString(command string, args ...string) *exec.Cmd {
-	shell := os.Getenv("SHELL")
-	if len(shell) == 0 {
-		shell = "sh"
-	}
+	shell := osutil.GetOptEnv("ZK_SHELL").
+		Or(osutil.GetOptEnv("SHELL")).
+		OrString("sh").
+		Unwrap()
+
 	args = append([]string{"-c", command, "--"}, args...)
 	return exec.Command(shell, args...)
 }


### PR DESCRIPTION
### Added

* [#163](https://github.com/mickael-menu/zk/issues/163) Use the `ZK_SHELL` environment variable to override the shell for `zk` only.

---

* Fix #163 