### PR TITLE
Fix windows build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# IDEs/Editors
+.vscode/
+
 notebook.db
 zk

--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -152,7 +152,8 @@ func (ns *NotebookStore) locateNotebook(path string) (string, error) {
 
 	var locate func(string) (string, error)
 	locate = func(currentPath string) (string, error) {
-		if currentPath == "/" || currentPath == "." {
+                // For Windows, the root dir may end with volume name, e.g. E:\\
+		if currentPath == "/" || currentPath == filepath.VolumeName(currentPath)+"\\" || currentPath == "." {
 			return "", ErrNotebookNotFound(path)
 		}
 		exists, err := ns.fs.DirExists(filepath.Join(currentPath, ".zk"))

--- a/internal/util/exec/exec_windows.go
+++ b/internal/util/exec/exec_windows.go
@@ -3,15 +3,16 @@ package exec
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 	"syscall"
 )
 
 // CommandFromString returns a Cmd running the given command.
-func CommandFromString(command string) *exec.Cmd {
+func CommandFromString(command string, args ...string) *exec.Cmd {
 	cmd := exec.Command("cmd")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    false,
-		CmdLine:       fmt.Sprintf(` /v:on/s/c "%s"`, command),
+		CmdLine:       fmt.Sprintf(` /v:on/s/c "%s %s"`, command, strings.Join(args[:], " ")),
 		CreationFlags: 0,
 	}
 	return cmd


### PR DESCRIPTION
Use variadic arguments in windows implementation of `CommandFromString`.
Check for windows root directory while searching for notebooks, this
fixes an infinite loop during startup notebook discovery. Fixes #139.

Please note that `go build -tags "fts5 icu"` will require a patch from
`go-sqlite3` [here][] with a msys2/mingw64 env.

[here]: https://github.com/mattn/go-sqlite3/pull/1017