### PR TITLE
Add `--id` flag to `zk new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 * New `--date` flag for `zk new` to set the current date manually.
+* New `--id` flag for `zk new` to skip ID generation and use a provided value (contributed by [@skbolton](https://github.com/mickael-menu/zk/pull/183)).
 * [#144](https://github.com/mickael-menu/zk/issues/144) LSP auto-completion of YAML frontmatter tags.
 * [zk-nvim#26](https://github.com/mickael-menu/zk-nvim/issues/26) The LSP server doesn't use `additionalTextEdits` anymore to remove the trigger characters when completing links.
     * You can customize the default behavior with the [`use-additional-text-edits` configuration key](docs/config-lsp.md).

--- a/internal/cli/cmd/new.go
+++ b/internal/cli/cmd/new.go
@@ -24,6 +24,7 @@ type New struct {
 	Template  string            `          placeholder:PATH  help:"Custom template used to render the note."`
 	PrintPath bool              `short:p                     help:"Print the path of the created note instead of editing it."`
 	DryRun    bool              `short:n                     help:"Don't actually create the note. Instead, prints its content on stdout and the generated path on stderr."`
+	ID        string            `          placeholder:ID    help:"Skip id generation and use provided value."`
 }
 
 func (cmd *New) Run(container *cli.Container) error {
@@ -54,6 +55,7 @@ func (cmd *New) Run(container *cli.Container) error {
 		Extra:     cmd.Extra,
 		Date:      date,
 		DryRun:    cmd.DryRun,
+		ID:        cmd.ID,
 	})
 
 	if cmd.DryRun {

--- a/tests/cmd-new.tesh
+++ b/tests/cmd-new.tesh
@@ -29,6 +29,7 @@ $ zk new --help
 >  -n, --dry-run                Don't actually create the note. Instead, prints
 >                               its content on stdout and the generated path on
 >                               stderr.
+>      --id=ID                  Skip id generation and use provided value.
 
 # Default note title.
 $ zk new --print-path
@@ -47,6 +48,10 @@ $ cat custom-title.md
 ># Custom title
 >
 >
+
+# Provide a custom note id
+$ zk new --group id --id 123abc --dry-run
+2>{{working-dir}}/123abc.md
 
 # Provide a custom title (short flag).
 $ zk new -t "Another custom title" -p

--- a/tests/fixtures/new/.zk/config.toml
+++ b/tests/fixtures/new/.zk/config.toml
@@ -10,6 +10,10 @@ filename = "{{date now '%d-%m'}}"
 template = "empty.md"
 filename = "{{now}}"
 
+[group.id.note]
+template = "empty.md"
+filename = "{{id}}"
+
 [group.handlebars.note]
 template = "handlebars.md"
 


### PR DESCRIPTION
This allows overriding the id generation step and just use a provided
value instead.