### PR TITLE
Add support for double star globbing in `note.ignore` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 * [zk-nvim#26](https://github.com/mickael-menu/zk-nvim/issues/26) The LSP server doesn't use `additionalTextEdits` anymore to remove the trigger characters when completing links.
     * You can customize the default behavior with the [`use-additional-text-edits` configuration key](docs/config-lsp.md).
 * [#163](https://github.com/mickael-menu/zk/issues/163) Use the `ZK_SHELL` environment variable to override the shell for `zk` only.
+* [#173](https://github.com/mickael-menu/zk/issues/173) Support for double star globbing in `note.ignore` config option.
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/alecthomas/kong v0.2.18-0.20210927063154-5c7b038540ab
 	github.com/aymerick/raymond v2.0.2+incompatible
+	github.com/bmatcuk/doublestar/v4 v4.0.2 // indirect
 	github.com/fatih/color v1.13.0
 	github.com/go-testfixtures/testfixtures/v3 v3.4.1
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=

--- a/internal/core/note_index.go
+++ b/internal/core/note_index.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/mickael-menu/zk/internal/util"
 	"github.com/mickael-menu/zk/internal/util/errors"
 	"github.com/mickael-menu/zk/internal/util/paths"
@@ -132,7 +133,7 @@ func (t *indexTask) execute(callback func(change paths.DiffChange)) (NoteIndexin
 		}
 
 		for _, ignoreGlob := range group.IgnoreGlobs() {
-			matches, err := filepath.Match(ignoreGlob, path)
+			matches, err := doublestar.PathMatch(ignoreGlob, path)
 			if err != nil {
 				return true, errors.Wrapf(err, "failed to match ignore glob %s to %s", ignoreGlob, path)
 			}

--- a/tests/issue-173.tesh
+++ b/tests/issue-173.tesh
@@ -1,0 +1,16 @@
+# Support for double star globbing with `note.ignore`.
+# https://github.com/mickael-menu/zk/issues/173
+
+$ cd blank
+
+$ echo "[note]\n ignore = ['drafts/**']" > .zk/config.toml
+
+$ mkdir -p drafts/subdir/subdir
+$ echo "# This is not ignored" > not-ignored.md
+$ echo "# This is ignored" > drafts/ignored.md
+$ echo "# This should be ignored as well" > drafts/subdir/should-ignore.md
+$ echo "# This should be ignored as well" > drafts/subdir/subdir/should-ignore.md
+
+$ zk list -qfpath
+>not-ignored.md
+


### PR DESCRIPTION
### Added

* [#173](https://github.com/mickael-menu/zk/issues/173) Support for double star globbing in `note.ignore` config option.

---

* Fix #173 