### PR TITLE
Don't parse Markdown table headers as colon tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 * [#126](https://github.com/mickael-menu/zk/issues/126) Embedded image links shown as not found.
 * [#152](https://github.com/mickael-menu/zk/issues/152) Incorrect timezone for natural dates.
 * [#170](https://github.com/mickael-menu/zk/issues/170) Broken wiki links in subdirectories.
+* [#185](https://github.com/mickael-menu/zk/issues/185) Don't parse a Markdown table header as a colon tag.
 
 
 ## 0.9.0

--- a/internal/adapter/markdown/extensions/tag.go
+++ b/internal/adapter/markdown/extensions/tag.go
@@ -226,7 +226,7 @@ func (p *colontagParser) Parse(parent ast.Node, block text.Reader, pc parser.Con
 
 		} else if char == ':' {
 			tag = strings.TrimSpace(tag)
-			if len(tag) == 0 {
+			if !isValidTag(tag) {
 				break
 			}
 			tags = append(tags, tag)
@@ -259,4 +259,20 @@ func isValidTagChar(r rune, excluded rune) bool {
 		r == '-' || r == '_' || r == '$' || r == '%' ||
 		r == '&' || r == '+' || r == '=' || r == ':' ||
 		r == '#')
+}
+
+func isValidTag(tag string) bool {
+	if len(tag) == 0 {
+		return false
+	}
+
+	// Prevent Markdown table syntax to be parsed a a colon tag, e.g. |:---:|
+	// https://github.com/mickael-menu/zk/issues/185
+	for _, c := range tag {
+		if c != '-' {
+			return true
+		}
+	}
+
+	return false
 }

--- a/tests/issue-185.tesh
+++ b/tests/issue-185.tesh
@@ -1,0 +1,12 @@
+# Markdown table syntax is parsed as colon tags
+# https://github.com/mickael-menu/zk/issues/185
+
+$ cd blank
+
+$ echo "[format.markdown] colon-tags = true" > .zk/config.toml
+$ echo "|:---:|" > test.md
+
+$ zk tag list
+2>
+2>Found 0 tag
+


### PR DESCRIPTION
### Fixed

* [#185](https://github.com/mickael-menu/zk/issues/185) Don't parse a Markdown table header as a colon tag.

---

* Fix #185 