### PR TITLE
Add Nix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Or, if you want to the latest changes:
 brew install --HEAD zk
 ```
 
+### Nix
+
+```sh
+# Run zk from Nix store without installing it:
+nix run nixpkgs#zk
+# Or, to install it permanently:
+nix-env -iA zk
+```
+
 ### Arch Linux
 
 You can install [the zk package](https://archlinux.org/packages/community/x86_64/zk/) from the official repos.


### PR DESCRIPTION
Apparently `zk` got added to nixpkgs:

- https://github.com/NixOS/nixpkgs/pull/143020

And incidentally, the vim extension as well (not yet merged):

- https://github.com/NixOS/nixpkgs/pull/164343