### PR TITLE
Hide index progress in non-interactive shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
     * For example, `[[Planet]]` can match a note with filename `i4w0 Planet.md` but not `i4w0.md` with a Markdown title `Planet` anymore.
     * This "smart" fallback resolution based on note titles was too fragile and not supported by the `zk` CLI.
 
+### Fixed
+
+* [#233](https://github.com/mickael-menu/zk/issues/233) Hide index progress in non-interactive shells.
+
 
 ## 0.10.1
 

--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -32,7 +32,8 @@ func (cmd *Init) Run(container *cli.Container) error {
 		return err
 	}
 
-	_, err = notebook.Index(core.NoteIndexOpts{})
+	index := Index{Quiet: true}
+	err = index.RunWithNotebook(container, notebook)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -103,7 +103,8 @@ func main() {
 		// command, otherwise it would hide the stats.
 		if ctx.Command() != "index" {
 			if notebook, err := container.CurrentNotebook(); err == nil {
-				_, err = notebook.Index(core.NoteIndexOpts{})
+				index := cmd.Index{Quiet: true}
+				err = index.RunWithNotebook(container, notebook)
 				ctx.FatalIfErrorf(err)
 			}
 		}


### PR DESCRIPTION
### Fixed

* [#233](https://github.com/mickael-menu/zk/issues/233) Hide index progress in non-interactive shells.

---

* Fixes #233 