### PR TITLE
Fix updating links after creating a new note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 * [#233](https://github.com/mickael-menu/zk/issues/233) Hide index progress in non-interactive shells.
+* [#236](https://github.com/mickael-menu/zk/issues/236) Fix updating links after creating a new note.
 
 
 ## 0.10.1

--- a/internal/adapter/sqlite/note_index.go
+++ b/internal/adapter/sqlite/note_index.go
@@ -179,6 +179,9 @@ func (ni *NoteIndex) linkMatchesPath(link core.ResolvedLink, path string) (bool,
 	}
 
 	matches := func(href string, allowPartialHref bool) bool {
+		if href == "" {
+			return false
+		}
 		href = regexp.QuoteMeta(href)
 
 		if allowPartialHref {
@@ -193,7 +196,7 @@ func (ni *NoteIndex) linkMatchesPath(link core.ResolvedLink, path string) (bool,
 		return matchString("^(?:"+href+"[^/]*|"+href+"/.+)$", path)
 	}
 
-	baseDir := filepath.Dir(link.SourcePath)
+	baseDir := filepath.Join(ni.notebookPath, filepath.Dir(link.SourcePath))
 	if relHref, err := ni.relNotebookPath(baseDir, href); err != nil {
 		if matches(relHref, false) {
 			return true, nil

--- a/tests/fixtures/issue-236/2022-07-06.md
+++ b/tests/fixtures/issue-236/2022-07-06.md
@@ -1,0 +1,9 @@
+---
+title: test note 1
+date: 2022-07-06
+tags: [tag1]
+---
+
+[test note 2](ud1o)
+[test note 3](8r8q)
+

--- a/tests/fixtures/issue-236/8r8q.md
+++ b/tests/fixtures/issue-236/8r8q.md
@@ -1,0 +1,7 @@
+---
+title: test note 3
+date: 2022-07-06
+tags: [tag1]
+---
+
+

--- a/tests/fixtures/issue-236/ud1o.md
+++ b/tests/fixtures/issue-236/ud1o.md
@@ -1,0 +1,8 @@
+---
+title: test note 2
+date: 2022-07-06
+tags: [tag1, tag2]
+---
+
+[test note 3](8r8q)
+

--- a/tests/issue-236.tesh
+++ b/tests/issue-236.tesh
@@ -1,0 +1,13 @@
+# Links broken after adding a new note
+# https://github.com/mickael-menu/zk/issues/236
+$ cd issue-236
+
+$ zk list -qfpath --link-to 8r8q
+>2022-07-06.md
+>ud1o.md
+
+$ zk new --print-path > /dev/null
+
+$ zk list -qfpath --link-to 8r8q
+>2022-07-06.md
+>ud1o.md


### PR DESCRIPTION
### Fixed

* [#236](https://github.com/mickael-menu/zk/issues/236) Fix updating links after creating a new note.

---

* Fixes #236 