### PR TITLE
Fix LSP link recognition with unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 * [#233](https://github.com/mickael-menu/zk/issues/233) Hide index progress in non-interactive shells.
-
+* [#235](https://github.com/mickael-menu/zk/issues/235) Fix LSP link recognition with unicode (contributed by [@zkbpkp](https://github.com/mickael-menu/zk/issues/235)).
 
 ## 0.10.1
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -189,6 +189,10 @@ func (d *document) DocumentLinks() ([]documentLink, error) {
 				return
 			}
 
+			// Go regexes work with bytes, but the LSP client expects character indexes.
+			start = strutil.ByteIndexToRuneIndex(line, start)
+			end = strutil.ByteIndexToRuneIndex(line, end)
+
 			links = append(links, documentLink{
 				Href: href,
 				Range: protocol.Range{

--- a/internal/util/strings/strings.go
+++ b/internal/util/strings/strings.go
@@ -148,3 +148,14 @@ func CopyList(list []string) []string {
 	copy(out, list)
 	return out
 }
+
+func ByteIndexToRuneIndex(s string, i int) int {
+	res := 0
+	for j, _ := range s {
+		if j >= i {
+			break
+		}
+		res += 1
+	}
+	return res
+}

--- a/internal/util/strings/strings_test.go
+++ b/internal/util/strings/strings_test.go
@@ -151,3 +151,28 @@ func TestWordAt(t *testing.T) {
 	test("one\ttwo\tthree", 5, "two")
 	test("one @:~two three", 5, "@:~two")
 }
+
+func TestByteIndexToRuneIndex(t *testing.T) {
+	test := func(s string, index int, expected int) {
+		assert.Equal(t, ByteIndexToRuneIndex(s, index), expected)
+	}
+
+	test("", 0, 0)
+
+	source := "une étoile bleuâtre"
+	test(source, -2, 0)
+	test(source, -1, 0)
+	test(source, 0, 0)
+	test(source, 1, 1)
+	test(source, 4, 4)
+	test(source, 5, 5)
+	test(source, 6, 5)
+	test(source, 7, 6)
+	test(source, 16, 15)
+	test(source, 17, 16)
+	test(source, 18, 16)
+	test(source, 19, 17)
+	test(source, 20, 18)
+	test(source, 21, 19)
+	test(source, 22, 19)
+}


### PR DESCRIPTION
### Fixed

* [#235](https://github.com/mickael-menu/zk/issues/235) Fix LSP link recognition with unicode (contributed by [@zkbpkp](https://github.com/mickael-menu/zk/issues/235)).

---

* Fixes #235 