### PR TITLE
Link to mickael-menu/zk-nvim instead of megalithic/zk.nvim

### DIFF
--- a/docs/editors-integration.md
+++ b/docs/editors-integration.md
@@ -2,7 +2,7 @@
 
 There are several extensions available to integrate `zk` in your favorite editor:
 
-* [`zk.nvim`](https://github.com/megalithic/zk.nvim) for Neovim 0.5+, maintained by [Seth Messer](https://github.com/megalithic)
+* [`zk-nvim`](https://github.com/mickael-menu/zk-nvim) for Neovim 0.5+
 * [`zk-vscode`](https://github.com/mickael-menu/zk-vscode) for Visual Studio Code
 
 ## Language Server Protocol


### PR DESCRIPTION
https://github.com/megalithic/zk.nvim has been archived for a while.

I'm assuming it is intended to link to the same plugin as in `README.md`.
