### PR TITLE
LSP: Add support for external URLs with `documentLink`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+* LSP: Support for external URLs with `documentLink`.
+
 ### Fixed
 
 * [#243](https://github.com/mickael-menu/zk/issues/243) LSP: Fixed finding backlink references for notes in a folder.

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -281,15 +281,24 @@ func NewServer(opts ServerOpts) *Server {
 
 		documentLinks := []protocol.DocumentLink{}
 		for _, link := range links {
-			target, err := server.noteForLink(link, notebook)
-			if target == nil || err != nil {
-				continue
+			var target string
+			if strutil.IsURL(link.Href) {
+				// External link
+				target = link.Href
+			} else {
+				// Internal note link
+				targetNote, err := server.noteForLink(link, notebook)
+				if targetNote != nil && err == nil {
+					target = targetNote.URI
+				}
 			}
 
-			documentLinks = append(documentLinks, protocol.DocumentLink{
-				Range:  link.Range,
-				Target: &target.URI,
-			})
+			if target != "" {
+				documentLinks = append(documentLinks, protocol.DocumentLink{
+					Range:  link.Range,
+					Target: &target,
+				})
+			}
 		}
 
 		return documentLinks, err


### PR DESCRIPTION
### Added

* LSP: Support for external URLs with `documentLink`.