### PR TITLE
Add exact-word match strategy

### DIFF
--- a/internal/adapter/sqlite/note_dao.go
+++ b/internal/adapter/sqlite/note_dao.go
@@ -524,6 +524,14 @@ func (d *NoteDAO) findRows(opts core.NoteFindOpts, selection noteSelection) (*sq
 		case core.MatchStrategyExact:
 			whereExprs = append(whereExprs, `n.raw_content LIKE '%' || ? || '%' ESCAPE '\'`)
 			args = append(args, escapeLikeTerm(opts.Match.String(), '\\'))
+		case core.MatchStrategyExactWord:
+			words := strings.Fields(opts.Match.String())
+			for range words {
+				whereExprs = append(whereExprs, `n.raw_content LIKE '%' || ? || '%' ESCAPE '\'`)
+			}
+			for _, word := range words {
+				args = append(args, escapeLikeTerm(word, '\\'))
+			}
 		case core.MatchStrategyFts:
 			snippetCol = `snippet(fts_match.notes_fts, 2, '<zk:match>', '</zk:match>', '…', 20)`
 			joinClauses = append(joinClauses, "JOIN notes_fts fts_match ON n.id = fts_match.rowid")

--- a/internal/core/note_find.go
+++ b/internal/core/note_find.go
@@ -170,6 +170,8 @@ const (
 	MatchStrategyFts MatchStrategy = iota + 1
 	// Exact text matching.
 	MatchStrategyExact
+	// Exact word matching.
+	MatchStrategyExactWord
 	// Regular expression.
 	MatchStrategyRe
 )
@@ -183,7 +185,9 @@ func MatchStrategyFromString(str string) (MatchStrategy, error) {
 		return MatchStrategyRe, nil
 	case "exact", "e":
 		return MatchStrategyExact, nil
+	case "exact-word", "w":
+		return MatchStrategyExactWord, nil
 	default:
-		return 0, fmt.Errorf("%s: unknown match strategy\ntry fts (full-text search), re (regular expression) or exact", str)
+		return 0, fmt.Errorf("%s: unknown match strategy\ntry fts (full-text search), re (regular expression), exact or exact-word", str)
 	}
 }


### PR DESCRIPTION
**_Not sure if this is too niche to merge, so it's currently without tests/docs/etc but if you're interested in merging it upstream I will fill out the rest._**

I'm trying to recreate notational velocity's UI with `zk`.

Notation velocity has a very simple search interface, it just splits the query on whitespace and looks for each token inside a note via `strstr`. Searches are always `and`'d. 

`zk` can *almost* do this but:

- fts+stemming tends to return too broad results for some words, or too slim for partial tokens (eg: searching for `buf` wont find `buffer`, but searching for `logging` _will_ find `log`, you can fix `buf` with `buf*` but `"logging"` will still find `log`).
  - disabling stemming would be per database, AFAICT you can't set it per query, this option would be pretty invasive to the codebase.
- regular expressions can be more explicit but will only match tokens in the order given.
- exact match is actually pretty close, perfect for single tokens, but by design looks for "a b", not "a" and "b".

This adds a new match strategy `exact-word` which behaves similar to exact but splits the match filter into words first.

Not sure if "exact-**word**" really describes the behaviour, as `dog` will intentionally match `dogbowl`, `catdog` and `dog`, -- so it's really exact-strings? substrings?  exact-terms? exact-word**s**? `--match-strategy notational-velocity`?

Alternatively, instead of adding an new strategy, the `-m` option could be extended to support multiple instances: `-m word -m word2`.