### PR TITLE
Fix --working-dir= and --notebook-dir= option parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,7 +266,6 @@ func parseDirs(args []string) (cli.Dirs, []string, error) {
 		return []string{str[:slice[0]], str[slice[1]:]}
 	}
 
-	// Check if str matches long, or if it matches str if not empty
 	matchesLongOrShort := func(str string, long string, short string) bool {
 		return str == long || (short != "" && str == short)
 	}

--- a/main.go
+++ b/main.go
@@ -266,7 +266,7 @@ func parseDirs(args []string) (cli.Dirs, []string, error) {
 		return []string{str[:slice[0]], str[slice[1]:]}
 	}
 
-  // Peek ahead at next value  and pair with current if it exists, otherwise return nil
+	// Peek ahead at next value  and pair with current if it exists, otherwise return nil
 	makePeekPair := func(args []string, index int) (pair []string) {
 		if len(args) <= (index + 1) {
 			return nil
@@ -282,8 +282,8 @@ func parseDirs(args []string) (cli.Dirs, []string, error) {
 		newArgs := []string{}
 		for i, arg := range args {
 			// We can be given "--notebook-dir x" (two args) or "--notebook-dir=x" (one arg)
-      // so we must test against the current argument split into two, and 
-      // the current argument + the next.
+			// so we must test against the current argument split into two, and
+			// the current argument + the next.
 			splitPair := makeSplitPair(arg)
 			peekPair := makePeekPair(args, i)
 			var option string
@@ -300,8 +300,8 @@ func parseDirs(args []string) (cli.Dirs, []string, error) {
 				// skip 2 ahead (arg and value)
 				newArgs = append(newArgs, args[i+2:]...)
 			} else {
-        // we either had no split pair or peek pair, or they didn't match the
-        // needle, so just save the given arg and keep looking.
+				// we either had no split pair or peek pair, or they didn't match the
+				// needle, so just save the given arg and keep looking.
 				newArgs = append(newArgs, arg)
 			}
 
@@ -310,9 +310,9 @@ func parseDirs(args []string) (cli.Dirs, []string, error) {
 				return path, newArgs, err
 			} else if option != "" && value == "" {
 				return "", newArgs, errors.New(option + " requires a path argument")
-			}	
-    }
-    return "", newArgs, nil
+			}
+		}
+		return "", newArgs, nil
 	}
 
 	d.NotebookDir, args, err = findFlag("--notebook-dir", "", args)

--- a/main.go
+++ b/main.go
@@ -310,6 +310,8 @@ func parseDirs(args []string) (cli.Dirs, []string, error) {
 				return path, newArgs, err
 			} else if option != "" && value == "" {
 				return "", newArgs, errors.New(option + " requires a path argument")
+			} else if len(args) == (i+1) && matchesLongOrShort(arg, long, short) {
+				return "", newArgs, errors.New(arg + " requires a path argument")
 			}
 		}
 		return "", newArgs, nil

--- a/tests/flag-notebook-dir.tesh
+++ b/tests/flag-notebook-dir.tesh
@@ -3,7 +3,9 @@
 2>zk: error: failed to open notebook: no notebook found in {{working-dir}} or a parent directory
 
 # Provide the notebook directory with `--notebook-dir`.
+# --notebook-dir is custom parsed, check that it handles both one and two arg forms
 $ zk index -q --notebook-dir paths
+$ zk index -q --notebook-dir=paths
 
 # Provide the notebook directory with the `ZK_NOTEBOOK_DIR` env variable.
 $ ZK_NOTEBOOK_DIR={{working-dir}}/paths zk index -q

--- a/tests/flag-working-dir.tesh
+++ b/tests/flag-working-dir.tesh
@@ -3,8 +3,18 @@ $ zk list -qfpath --working-dir paths
 >paper.md
 >brown/wood.md
 
+# working-dir is custom parsed, check that it handles both one and two arg forms
+$ zk list -qfpath --working-dir=paths
+>paper.md
+>brown/wood.md
+
 # Short flag.
 $ zk list -qfpath -W paths
+>paper.md
+>brown/wood.md
+
+# working-dir is custom parsed, check that it handles both one and two arg forms
+$ zk list -qfpath -W=paths
 >paper.md
 >brown/wood.md
 


### PR DESCRIPTION
--working-dir and --notebook-dir options run through some custom parsing code before everything else so it can apply to aliases.

When given in the form --working-dir=x (with an =), the previous implementation would check this as a single option instead of separating it into an option=value pair, which would mean --working-dir=, -W= and --notebook-dir= would not be recognised when given.