### PR TITLE
Adds "title" to the Command in code actions

### DIFF
--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -428,6 +428,7 @@ func NewServer(opts ServerOpts) *Server {
 				Title: actionTitle,
 				Kind:  stringPtr(protocol.CodeActionKindRefactor),
 				Command: &protocol.Command{
+					Title:   actionTitle,
 					Command:   cmdNew,
 					Arguments: []interface{}{wd, jsonOpts},
 				},

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -428,7 +428,7 @@ func NewServer(opts ServerOpts) *Server {
 				Title: actionTitle,
 				Kind:  stringPtr(protocol.CodeActionKindRefactor),
 				Command: &protocol.Command{
-					Title:   actionTitle,
+					Title:     actionTitle,
 					Command:   cmdNew,
 					Arguments: []interface{}{wd, jsonOpts},
 				},


### PR DESCRIPTION
This fixes issue with some clients (see for example this [kak-lsp issue](https://github.com/kak-lsp/kak-lsp/issues/669)) expecting to find a non empty string there to display.