### PR TITLE
Use UTF-16 to get the correct position

### DIFF
--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/mickael-menu/zk/internal/core"
 	"github.com/mickael-menu/zk/internal/util"
@@ -129,32 +130,34 @@ func (d *document) GetLines() []string {
 }
 
 // LookBehind returns the n characters before the given position, on the same line.
-func (d *document) LookBehind(pos protocol.Position, length int) string {
+func (d *document) LookBehind(pos protocol.Position, length int) []uint16 {
 	line, ok := d.GetLine(int(pos.Line))
+	utf16Bytes := utf16.Encode([]rune(line))
 	if !ok {
-		return ""
+		return utf16.Encode([]rune(""))
 	}
 
 	charIdx := int(pos.Character)
 	if length > charIdx {
-		return line[0:charIdx]
+		return utf16Bytes[0:charIdx]
 	}
-	return line[(charIdx - length):charIdx]
+	return utf16Bytes[(charIdx - length):charIdx]
 }
 
 // LookForward returns the n characters after the given position, on the same line.
-func (d *document) LookForward(pos protocol.Position, length int) string {
+func (d *document) LookForward(pos protocol.Position, length int) []uint16 {
 	line, ok := d.GetLine(int(pos.Line))
+	utf16Bytes := utf16.Encode([]rune(line))
 	if !ok {
-		return ""
+		return utf16.Encode([]rune(""))
 	}
 
-	lineLength := len(line)
+	lineLength := len(utf16Bytes)
 	charIdx := int(pos.Character)
 	if lineLength <= charIdx+length {
-		return line[charIdx:]
+		return utf16Bytes[charIdx:]
 	}
-	return line[charIdx:(charIdx + length)]
+	return utf16Bytes[charIdx:(charIdx + length)]
 }
 
 var wikiLinkRegex = regexp.MustCompile(`\[?\[\[(.+?)(?: *\| *(.+?))?\]\]`)

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -130,34 +130,34 @@ func (d *document) GetLines() []string {
 }
 
 // LookBehind returns the n characters before the given position, on the same line.
-func (d *document) LookBehind(pos protocol.Position, length int) []uint16 {
+func (d *document) LookBehind(pos protocol.Position, length int) string {
 	line, ok := d.GetLine(int(pos.Line))
 	utf16Bytes := utf16.Encode([]rune(line))
 	if !ok {
-		return utf16.Encode([]rune(""))
+		return ""
 	}
 
 	charIdx := int(pos.Character)
 	if length > charIdx {
-		return utf16Bytes[0:charIdx]
+		return string(utf16.Decode(utf16Bytes[0:charIdx]))
 	}
-	return utf16Bytes[(charIdx - length):charIdx]
+	return string(utf16.Decode(utf16Bytes[(charIdx - length):charIdx]))
 }
 
 // LookForward returns the n characters after the given position, on the same line.
-func (d *document) LookForward(pos protocol.Position, length int) []uint16 {
+func (d *document) LookForward(pos protocol.Position, length int) string {
 	line, ok := d.GetLine(int(pos.Line))
 	utf16Bytes := utf16.Encode([]rune(line))
 	if !ok {
-		return utf16.Encode([]rune(""))
+		return ""
 	}
 
 	lineLength := len(utf16Bytes)
 	charIdx := int(pos.Character)
 	if lineLength <= charIdx+length {
-		return utf16Bytes[charIdx:]
+		return string(utf16.Decode(utf16Bytes[charIdx:]))
 	}
-	return utf16Bytes[charIdx:(charIdx + length)]
+	return string(utf16.Decode(utf16Bytes[charIdx:(charIdx + length)]))
 }
 
 var wikiLinkRegex = regexp.MustCompile(`\[?\[\[(.+?)(?: *\| *(.+?))?\]\]`)


### PR DESCRIPTION
Fix https://github.com/mickael-menu/zk-nvim/issues/69.

According to https://pkg.go.dev/go.lsp.dev/protocol#Position, "The offsets are based on a UTF-16 string representation".

Other code that uses protocol.Position may also have similar issues, but I only fixed the part that affects autocompletion.