### PR TITLE
Rename `note.ignore` config property to `note.exclude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 * Removed the dependency on `libicu`.
+* The `note.ignore` configuration property was renamed to `note.exclude`, to be more consistent with the CLI flags.
 
 ### Fixed
 

--- a/docs/config-note.md
+++ b/docs/config-note.md
@@ -14,8 +14,8 @@ The `[note]` section from the [configuration file](config.md) is used to set the
 * `template` (string)
     * Path to the [template](template.md) used to generate the note content.
     * Either an absolute path, or relative to `.zk/templates/`.
-* `ignore` (list of strings)
-    * List of [path globs](https://en.wikipedia.org/wiki/Glob_\(programming\)) ignored during note indexing.
+* `exclude` (list of strings)
+    * List of [path globs](https://en.wikipedia.org/wiki/Glob_\(programming\)) excluded during note indexing.
 * `id-charset` (string)
     * Characters set used to [generate random IDs](note-id.md).
     * You can use:

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -40,7 +40,7 @@ func NewDefaultConfig() Config {
 				Length:  4,
 				Case:    CaseLower,
 			},
-			Ignore: []string{},
+			Exclude: []string{},
 		},
 		Groups: map[string]GroupConfig{},
 		Format: FormatConfig{
@@ -216,7 +216,7 @@ type NoteConfig struct {
 	// Settings used when generating a random ID.
 	IDOptions IDOptions
 	// Path globs to ignore when indexing notes.
-	Ignore []string
+	Exclude []string
 }
 
 // GroupConfig holds the user configuration for a given group of notes.
@@ -226,16 +226,16 @@ type GroupConfig struct {
 	Extra map[string]string
 }
 
-// IgnoreGlobs returns all the Note.Ignore path globs for the group paths,
+// ExcludeGlobs returns all the Note.Exclude path globs for the group paths,
 // relative to the root of the notebook.
-func (c GroupConfig) IgnoreGlobs() []string {
+func (c GroupConfig) ExcludeGlobs() []string {
 	if len(c.Paths) == 0 {
-		return c.Note.Ignore
+		return c.Note.Exclude
 	}
 
 	globs := []string{}
 	for _, p := range c.Paths {
-		for _, g := range c.Note.Ignore {
+		for _, g := range c.Note.Exclude {
 			globs = append(globs, filepath.Join(p, g))
 		}
 	}
@@ -325,8 +325,11 @@ func ParseConfig(content []byte, path string, parentConfig Config, isGlobal bool
 	if note.DefaultTitle != "" {
 		config.Note.DefaultTitle = note.DefaultTitle
 	}
+	for _, v := range note.Exclude {
+		config.Note.Exclude = append(config.Note.Exclude, v)
+	}
 	for _, v := range note.Ignore {
-		config.Note.Ignore = append(config.Note.Ignore, v)
+		config.Note.Exclude = append(config.Note.Exclude, v)
 	}
 	if tomlConf.Extra != nil {
 		for k, v := range tomlConf.Extra {
@@ -477,8 +480,11 @@ func (c GroupConfig) merge(tomlConf tomlGroupConfig, name string) GroupConfig {
 	if note.DefaultTitle != "" {
 		res.Note.DefaultTitle = note.DefaultTitle
 	}
+	for _, v := range note.Exclude {
+		res.Note.Exclude = append(res.Note.Exclude, v)
+	}
 	for _, v := range note.Ignore {
-		res.Note.Ignore = append(res.Note.Ignore, v)
+		res.Note.Exclude = append(res.Note.Exclude, v)
 	}
 	if tomlConf.Extra != nil {
 		for k, v := range tomlConf.Extra {
@@ -515,7 +521,8 @@ type tomlNoteConfig struct {
 	IDCharset    string   `toml:"id-charset"`
 	IDLength     int      `toml:"id-length"`
 	IDCase       string   `toml:"id-case"`
-	Ignore       []string `toml:"ignore"`
+	Exclude      []string `toml:"exclude"`
+	Ignore      []string `toml:"ignore"` // Legacy alias to `exclude`
 }
 
 type tomlGroupConfig struct {

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -28,7 +28,7 @@ func TestParseDefaultConfig(t *testing.T) {
 			},
 			DefaultTitle: "Untitled",
 			Lang:         "en",
-			Ignore:       []string{},
+			Exclude:      []string{},
 		},
 		Groups: make(map[string]GroupConfig),
 		Format: FormatConfig{
@@ -81,7 +81,7 @@ func TestParseComplete(t *testing.T) {
 		id-charset = "alphanum"
 		id-length = 4
 		id-case = "lower"
-		ignore = ["ignored", ".git"]
+		exclude = ["ignored", ".git"]
 
 		[format.markdown]
 		hashtags = false
@@ -124,7 +124,7 @@ func TestParseComplete(t *testing.T) {
 		id-charset = "letters"
 		id-length = 8
 		id-case = "mixed"
-		ignore = ["new-ignored"]
+		exclude = ["new-ignored"]
 		
 		[group.log.extra]
 		log-ext = "value"
@@ -162,7 +162,7 @@ func TestParseComplete(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
-			Ignore:       []string{"ignored", ".git"},
+			Exclude:      []string{"ignored", ".git"},
 		},
 		Groups: map[string]GroupConfig{
 			"log": {
@@ -178,7 +178,7 @@ func TestParseComplete(t *testing.T) {
 					},
 					Lang:         "de",
 					DefaultTitle: "Ohne Titel",
-					Ignore:       []string{"ignored", ".git", "new-ignored"},
+					Exclude:      []string{"ignored", ".git", "new-ignored"},
 				},
 				Extra: map[string]string{
 					"hello":   "world",
@@ -199,7 +199,7 @@ func TestParseComplete(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
-					Ignore:       []string{"ignored", ".git"},
+					Exclude:      []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello": "world",
@@ -219,7 +219,7 @@ func TestParseComplete(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
-					Ignore:       []string{"ignored", ".git"},
+					Exclude:      []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello": "world",
@@ -286,7 +286,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 		id-charset = "letters"
 		id-length = 42
 		id-case = "upper"
-		ignore = ["ignored", ".git"]
+		exclude = ["ignored", ".git"]
 
 		[extra]
 		hello = "world"
@@ -319,7 +319,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
-			Ignore:       []string{"ignored", ".git"},
+			Exclude:      []string{"ignored", ".git"},
 		},
 		Groups: map[string]GroupConfig{
 			"log": {
@@ -335,7 +335,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
-					Ignore:       []string{"ignored", ".git"},
+					Exclude:      []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello":   "override",
@@ -356,7 +356,7 @@ func TestParseMergesGroupConfig(t *testing.T) {
 					},
 					Lang:         "fr",
 					DefaultTitle: "Sans titre",
-					Ignore:       []string{"ignored", ".git"},
+					Exclude:      []string{"ignored", ".git"},
 				},
 				Extra: map[string]string{
 					"hello": "world",
@@ -515,31 +515,31 @@ func TestParseLSPDiagnosticsSeverity(t *testing.T) {
 	assert.Err(t, err, "foobar: unknown LSP diagnostic severity - may be none, hint, info, warning or error")
 }
 
-func TestGroupConfigIgnoreGlobs(t *testing.T) {
+func TestGroupConfigExcludeGlobs(t *testing.T) {
 	// empty globs
 	config := GroupConfig{
 		Paths: []string{"path"},
-		Note:  NoteConfig{Ignore: []string{}},
+		Note:  NoteConfig{Exclude: []string{}},
 	}
-	assert.Equal(t, config.IgnoreGlobs(), []string{})
+	assert.Equal(t, config.ExcludeGlobs(), []string{})
 
 	// empty paths
 	config = GroupConfig{
 		Paths: []string{},
 		Note: NoteConfig{
-			Ignore: []string{"ignored", ".git"},
+			Exclude: []string{"ignored", ".git"},
 		},
 	}
-	assert.Equal(t, config.IgnoreGlobs(), []string{"ignored", ".git"})
+	assert.Equal(t, config.ExcludeGlobs(), []string{"ignored", ".git"})
 
 	// several paths
 	config = GroupConfig{
 		Paths: []string{"log", "drafts"},
 		Note: NoteConfig{
-			Ignore: []string{"ignored", "*.git"},
+			Exclude: []string{"ignored", "*.git"},
 		},
 	}
-	assert.Equal(t, config.IgnoreGlobs(), []string{"log/ignored", "log/*.git", "drafts/ignored", "drafts/*.git"})
+	assert.Equal(t, config.ExcludeGlobs(), []string{"log/ignored", "log/*.git", "drafts/ignored", "drafts/*.git"})
 }
 
 func TestGroupConfigClone(t *testing.T) {
@@ -556,7 +556,7 @@ func TestGroupConfigClone(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
-			Ignore:       []string{"ignored", ".git"},
+			Exclude:      []string{"ignored", ".git"},
 		},
 		Extra: map[string]string{
 			"hello": "world",
@@ -576,7 +576,7 @@ func TestGroupConfigClone(t *testing.T) {
 	clone.Note.IDOptions.Case = CaseUpper
 	clone.Note.Lang = "de"
 	clone.Note.DefaultTitle = "Ohne Titel"
-	clone.Note.Ignore = []string{"other-ignored"}
+	clone.Note.Exclude = []string{"other-ignored"}
 	clone.Extra["test"] = "modified"
 
 	// Check that we didn't modify the original
@@ -593,7 +593,7 @@ func TestGroupConfigClone(t *testing.T) {
 			},
 			Lang:         "fr",
 			DefaultTitle: "Sans titre",
-			Ignore:       []string{"ignored", ".git"},
+			Exclude:      []string{"ignored", ".git"},
 		},
 		Extra: map[string]string{
 			"hello": "world",

--- a/internal/core/note_index.go
+++ b/internal/core/note_index.go
@@ -136,13 +136,13 @@ func (t *indexTask) execute(callback func(change paths.DiffChange)) (NoteIndexin
 			return true, nil
 		}
 
-		for _, ignoreGlob := range group.IgnoreGlobs() {
+		for _, ignoreGlob := range group.ExcludeGlobs() {
 			matches, err := doublestar.PathMatch(ignoreGlob, path)
 			if err != nil {
-				return true, errors.Wrapf(err, "failed to match ignore glob %s to %s", ignoreGlob, path)
+				return true, errors.Wrapf(err, "failed to match exclude glob %s to %s", ignoreGlob, path)
 			}
 			if matches {
-				notifyIgnored("matched ignore glob \"" + ignoreGlob + "\"")
+				notifyIgnored("matched exclude glob \"" + ignoreGlob + "\"")
 				return true, nil
 			}
 		}

--- a/tests/cmd-index-legacy-ignore.tesh
+++ b/tests/cmd-index-legacy-ignore.tesh
@@ -1,0 +1,15 @@
+$ cd legacy-ignore
+
+# Index initial notes.
+$ zk index
+>Indexed 3 notes in 0s
+>  + 3 added
+>  ~ 0 modified
+>  - 0 removed
+
+# Ignore path patterns.
+$ touch carrot-ignored/ananas.md && zk index
+>Indexed 3 notes in 0s
+>  + 0 added
+>  ~ 0 modified
+>  - 0 removed

--- a/tests/cmd-index.tesh
+++ b/tests/cmd-index.tesh
@@ -99,8 +99,8 @@ $ touch banana.md && echo "More" >> litchee.md && rm eggplant/apple.md && zk ind
 >- removed eggplant/apple.md
 >- unchanged eggplant/clementine.md
 >- modified litchee.md
->- ignored carrot-ignored/ananas.md: matched ignore glob "carrot-ignored/*"
->- ignored carrot-ignored/tomato.md: matched ignore glob "carrot-ignored/*"
+>- ignored carrot-ignored/ananas.md: matched exclude glob "carrot-ignored/*"
+>- ignored carrot-ignored/tomato.md: matched exclude glob "carrot-ignored/*"
 >- ignored orange.markdown: expected extension "md"
 >
 >Indexed 3 notes in 0s
@@ -113,8 +113,8 @@ $ zk index -v
 >- unchanged banana.md
 >- unchanged eggplant/clementine.md
 >- unchanged litchee.md
->- ignored carrot-ignored/ananas.md: matched ignore glob "carrot-ignored/*"
->- ignored carrot-ignored/tomato.md: matched ignore glob "carrot-ignored/*"
+>- ignored carrot-ignored/ananas.md: matched exclude glob "carrot-ignored/*"
+>- ignored carrot-ignored/tomato.md: matched exclude glob "carrot-ignored/*"
 >- ignored orange.markdown: expected extension "md"
 >
 >Indexed 3 notes in 0s

--- a/tests/config-note-exclude.tesh
+++ b/tests/config-note-exclude.tesh
@@ -8,12 +8,12 @@ $ touch dir/orange.md
 $ touch dir/subdir/apple.md
 
 # Ignore a file in the root directory.
-$ echo "[note]\n ignore = ['orange.md']" > .zk/config.toml
+$ echo "[note]\n exclude = ['orange.md']" > .zk/config.toml
 $ zk index -v
 >- added banana.md
 >- added dir/orange.md
 >- added dir/subdir/apple.md
->- ignored orange.md: matched ignore glob "orange.md"
+>- ignored orange.md: matched exclude glob "orange.md"
 >
 >Indexed 3 notes in 0s
 >  + 3 added
@@ -21,13 +21,13 @@ $ zk index -v
 >  - 0 removed
 
 # Ignore with wildcards.
-$ echo "[note]\n ignore = ['*rang*', 'dir/*']" > .zk/config.toml
+$ echo "[note]\n exclude = ['*rang*', 'dir/*']" > .zk/config.toml
 $ zk index -v
 >- unchanged banana.md
 >- removed dir/orange.md
 >- unchanged dir/subdir/apple.md
->- ignored dir/orange.md: matched ignore glob "dir/*"
->- ignored orange.md: matched ignore glob "*rang*"
+>- ignored dir/orange.md: matched exclude glob "dir/*"
+>- ignored orange.md: matched exclude glob "*rang*"
 >
 >Indexed 2 notes in 0s
 >  + 0 added

--- a/tests/fixtures/legacy-ignore/.zk/config.toml
+++ b/tests/fixtures/legacy-ignore/.zk/config.toml
@@ -1,4 +1,4 @@
 [note]
-exclude = [
+ignore = [
     "carrot-ignored/*",
 ]

--- a/tests/fixtures/legacy-ignore/banana.md
+++ b/tests/fixtures/legacy-ignore/banana.md
@@ -1,0 +1,3 @@
+# Banana
+
+Content of banana

--- a/tests/fixtures/legacy-ignore/carrot-ignored/tomato.md
+++ b/tests/fixtures/legacy-ignore/carrot-ignored/tomato.md
@@ -1,0 +1,3 @@
+# Tomato
+
+Content of tomato

--- a/tests/fixtures/legacy-ignore/eggplant/clementine.md
+++ b/tests/fixtures/legacy-ignore/eggplant/clementine.md
@@ -1,0 +1,3 @@
+# Clementine
+
+Content of clementine

--- a/tests/fixtures/legacy-ignore/litchee.md
+++ b/tests/fixtures/legacy-ignore/litchee.md
@@ -1,0 +1,3 @@
+# Litchee
+
+Content of litchee

--- a/tests/issue-173.tesh
+++ b/tests/issue-173.tesh
@@ -3,7 +3,7 @@
 
 $ cd blank
 
-$ echo "[note]\n ignore = ['drafts/**']" > .zk/config.toml
+$ echo "[note]\n exclude = ['drafts/**']" > .zk/config.toml
 
 $ mkdir -p drafts/subdir/subdir
 $ echo "# This is not ignored" > not-ignored.md


### PR DESCRIPTION
### Changed

* The `note.ignore` configuration property was renamed to `note.exclude`, to be more consistent with the CLI flags.

---

* Fix #313 