### PR TITLE
Address io/ioutil deprecation

### DIFF
--- a/internal/adapter/fs/fs.go
+++ b/internal/adapter/fs/fs.go
@@ -1,7 +1,6 @@
 package fs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,7 +113,7 @@ func (fs *FileStorage) IsDescendantOf(dir string, path string) (bool, error) {
 }
 
 func (fs *FileStorage) Read(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func (fs *FileStorage) Write(path string, content []byte) error {

--- a/internal/adapter/lsp/server.go
+++ b/internal/adapter/lsp/server.go
@@ -3,7 +3,7 @@ package lsp
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -209,7 +209,7 @@ func NewServer(opts ServerOpts) *Server {
 
 	handler.CompletionItemResolve = func(context *glsp.Context, params *protocol.CompletionItem) (*protocol.CompletionItem, error) {
 		if path, ok := params.Data.(string); ok {
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				return params, err
 			}
@@ -250,7 +250,7 @@ func NewServer(opts ServerOpts) *Server {
 		}
 		path = fs.Canonical(path)
 
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/cmd/new.go
+++ b/internal/cli/cmd/new.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -36,7 +36,7 @@ func (cmd *New) Run(container *cli.Container) error {
 
 	var content []byte
 	if cmd.Interactive {
-		content, err = ioutil.ReadAll(os.Stdin)
+		content, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Package io/ioutil was deprecated in Go 1.16.

This replaces the use of functions from io/ioutil with equivalent ones from the io and os packages. This allows to more easily upgrade the version of Go used to build zk.

Refs:
  https://pkg.go.dev/io/ioutil