### PR TITLE
chore(ci): use 'go-version-file' option in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version-file: 'go.mod'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This sets up Go using the Go version from the `go.mod` file.
It makes it easier to keep the Go version in sync between the `go.mod` file and the GH workflow files.