### PR TITLE
fetch flags to support tesh cases

### DIFF
--- a/tests/flag-version.tesh
+++ b/tests/flag-version.tesh
@@ -1,3 +1,3 @@
 $ zk --version
->zk {{sh "git describe --tags --always --dirty --match 'v[0-9]*' | cut -c2-"}}
+>zk {{sh "[ -e .git ] && git describe --tags --always --dirty --match 'v[0-9]*' | cut -c2- || sed 's/^v//' VERSION.txt"}}
 


### PR DESCRIPTION
flag-version.tesh is failing in ci. The output shows that the version is not being read, only the commit ref. As was pointed out to me before in #556 , git tags need to be present in order to get that version info. So hopefully that fixes the failing tesh case here too.