### PR TITLE
Implement --missing-backlink filter for zk list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: `<description> (<contributor>, <commit>)`
 
 ## Unreleased
 
+## Added
+
+- Find notes with missing backlinks using `zk list --missing-backlink`
+
 ## Fixed
 
 - Release tarballs now output the program version (by @WhyNotHugo, 344b99f)

--- a/docs/config/config-alias.md
+++ b/docs/config/config-alias.md
@@ -185,6 +185,14 @@ This is such a useful command, that an alias might be helpful.
 bl = "zk list --link-to $@"
 ```
 
+### Fix missing backlinks interactively
+
+Edit notes that have incoming links but don't link back to them.
+
+```toml
+fix-backlinks = "zk edit --interactive --missing-backlink"
+```
+
 ### Locate unlinked mentions in a note
 
 This alias can help you look for potential new links to establish, by listing

--- a/docs/notes/note-filtering.md
+++ b/docs/notes/note-filtering.md
@@ -281,6 +281,9 @@ two notes with `--max-distance <count>`.
 Finally, it can be useful to see which notes have no links pointing to them at
 all. You can use the `--orphan` option for this.
 
+You can also find notes that are targets of links from other notes but don't
+link back to them using `--missing-backlink`.
+
 ## Find related notes
 
 Part of writing a great notebook is to establish links between related notes.

--- a/internal/adapter/sqlite/note_dao.go
+++ b/internal/adapter/sqlite/note_dao.go
@@ -657,6 +657,19 @@ WHERE collection_id IN (SELECT id FROM collections t WHERE kind = '%s' AND (%s))
 		whereExprs = append(whereExprs, `tags IS NULL`)
 	}
 
+	if opts.MissingBacklink {
+		whereExprs = append(whereExprs, `n.id IN (
+			SELECT DISTINCT incoming.target_id
+			FROM links incoming
+			LEFT JOIN links outgoing ON (
+				outgoing.source_id = incoming.target_id
+				AND outgoing.target_id = incoming.source_id
+			)
+			WHERE incoming.target_id IS NOT NULL
+			  AND outgoing.source_id IS NULL
+		)`)
+	}
+
 	if opts.CreatedStart != nil {
 		whereExprs = append(whereExprs, "created >= ?")
 		args = append(args, opts.CreatedStart)

--- a/internal/adapter/sqlite/note_dao_test.go
+++ b/internal/adapter/sqlite/note_dao_test.go
@@ -965,6 +965,13 @@ func TestNoteDAOFindOrphan(t *testing.T) {
 	)
 }
 
+func TestNoteDAOFindMissingBacklink(t *testing.T) {
+	testNoteDAOFindPaths(t,
+		core.NoteFindOpts{MissingBacklink: true},
+		[]string{"f39c8.md", "ref/test/a.md", "log/2021-01-03.md", "index.md", "log/2021-01-04.md"},
+	)
+}
+
 func TestNoteDAOFindCreatedOn(t *testing.T) {
 	start := time.Date(2020, 11, 22, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2020, 11, 23, 0, 0, 0, 0, time.UTC)

--- a/internal/cli/filtering.go
+++ b/internal/cli/filtering.go
@@ -30,6 +30,7 @@ type Filtering struct {
 	NoLinkedBy     []string `kong:"group='filter',placeholder='PATH',help='Find notes which are not linked by the given ones.'" json:"-"`
 	Orphan         bool     `kong:"group='filter',help='Find notes which are not linked by any other note.'" json:"orphan"`
 	Tagless        bool     `kong:"group='filter',help='Find notes which have no tags.'" json:"tagless"`
+	MissingBacklink bool    `kong:"group='filter',help='Find notes with at least one missing backlink.'" json:"missingBacklink"`
 	Related        []string `kong:"group='filter',placeholder='PATH',help='Find notes which might be related to the given ones.'" json:"related"`
 	MaxDistance    int      `kong:"group='filter',placeholder='COUNT',help='Maximum distance between two linked notes.'" json:"maxDistance"`
 	Recursive      bool     `kong:"group='filter',short='r',help='Follow links recursively.'" json:"recursive"`
@@ -91,6 +92,7 @@ func (f Filtering) ExpandNamedFilters(filters map[string]string, expandedFilters
 			f.Interactive = f.Interactive || parsedFilter.Interactive
 			f.Orphan = f.Orphan || parsedFilter.Orphan
 			f.Tagless = f.Tagless || parsedFilter.Tagless
+			f.MissingBacklink = f.MissingBacklink || parsedFilter.MissingBacklink
 			f.Recursive = f.Recursive || parsedFilter.Recursive
 
 			if f.Limit == 0 {
@@ -206,6 +208,7 @@ func (f Filtering) NewNoteFindOpts(notebook *core.Notebook) (core.NoteFindOpts, 
 
 	opts.Orphan = f.Orphan
 	opts.Tagless = f.Tagless
+	opts.MissingBacklink = f.MissingBacklink
 
 	if f.Created != "" {
 		start, end, err := parseDayRange(f.Created)

--- a/internal/core/note_find.go
+++ b/internal/core/note_find.go
@@ -40,6 +40,8 @@ type NoteFindOpts struct {
 	Orphan bool
 	// Filter to select notes having no tags.
 	Tagless bool
+	// Filter to select notes with at least one missing backlink.
+	MissingBacklink bool
 	// Filter notes created after the given date.
 	CreatedStart *time.Time
 	// Filter notes created before the given date.


### PR DESCRIPTION
Add new filtering flag to find notes with incoming links that lack reciprocal backlinks.