### PR TITLE
docs: fixes link to lsp docs in the generated init config

### DIFF
--- a/internal/core/notebook_store.go
+++ b/internal/core/notebook_store.go
@@ -316,7 +316,7 @@ multiword-tags = false
 # LSP
 #
 #   Configure basic editor integration for LSP-compatible editors.
-#   See https://github.com/zk-org/zk/blob/main/docs/editors-integration.md
+#   See https://zk-org.github.io/zk/tips/editors-integration.html
 #
 [lsp]
 

--- a/tests/cmd-init-defaults.tesh
+++ b/tests/cmd-init-defaults.tesh
@@ -126,7 +126,7 @@ $ cat .zk/config.toml
 ># LSP
 >#
 >#   Configure basic editor integration for LSP-compatible editors.
->#   See https://github.com/zk-org/zk/blob/main/docs/editors-integration.md
+>#   See https://zk-org.github.io/zk/tips/editors-integration.html
 >#
 >[lsp]
 >


### PR DESCRIPTION
Fixes broken link to LSP configuration described in #584.