### PR TITLE
Add editor LSP configuration for Helix

### DIFF
--- a/docs/tips/editors-integration.md
+++ b/docs/tips/editors-integration.md
@@ -112,6 +112,32 @@ end })
 
 </details>
 
+#### Helix
+
+Add the following to your `languages.toml` file:
+
+<details><summary><tt>~/.config/helix/languages.toml</tt></summary>
+
+```toml
+[language-server.zk]
+command = "zk"
+args = ["lsp"]
+
+[[language]]
+name = "markdown"
+roots = [".zk"]
+language-servers = ["zk"]
+```
+
+<!-- prettier-ignore -->
+:::{note}
+This configuration disables Helix's
+[default language servers](https://docs.helix-editor.com/lang-support.html) for
+Markdown.
+:::
+
+</details>
+
 #### Sublime Text
 
 Install the [Sublime LSP](https://github.com/sublimelsp/LSP) package, then run


### PR DESCRIPTION
This PR adds a simple LSP configuration for the [Helix](https://helix-editor.com/) editor.