### PR TITLE
adapt build-binaries workflow to run on dev

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -37,7 +37,7 @@ jobs:
             ghcr.io/zk-org/zk-xcompile:${{ matrix.tag }} \
             /bin/bash -c 'go build -buildvcs=false -tags "fts5" -ldflags "-X=main.Version=${{ steps.vars.outputs.version }} -X=main.Build=${{ steps.vars.outputs.version }}"'
       - name: Compress for upload.
-        if: github.ref == 'refs/heads/main' && startsWith(steps.vars.outputs.version, 'v')
+        if: startsWith(steps.vars.outputs.version, 'v')
         run: tar -cvz zk > zk-${{ steps.vars.outputs.version }}-${{ matrix.tag }}.tar.gz
       - name: upload artifact
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
As discussed in #626, we want to check the binary builders for each architechture on commits to dev. This way we can catch any issues before triggering a proper release. 

The build-binaries workflow has an upload step, which uploads the artifacts to a tagged release.
We of course don't want this to happen on normal 'test' runs on the commits to dev.

I figured it was better to use a conditional to check the branch and the presence of a tag. 
This way we don't need to maintain a separate workflow for building binaries only in dev CI. 
And can be sure that if it passes on dev, it will pass on main. 

