### PR TITLE
docs: mention `zk-emacs` (Emacs integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ video,
   mentions
 - [Integration with your favorite editors](https://zk-org.github.io/zk/tips/editors-integration.html):
   - [Any LSP-compatible editor](https://zk-org.github.io/zk/tips/editors-integration.html)
+  - [`zk-emacs`](https://codeberg.org/mcookly/zk-emacs) for Emacs
   - [`zk-nvim`](https://github.com/zk-org/zk-nvim) for Neovim 0.8+
   - [`zk-vscode`](https://github.com/zk-org/zk-vscode) for Visual Studio Code
 - [Interactive browser](https://zk-org.github.io/zk/config/tool-fzf.html),

--- a/docs/tips/editors-integration.md
+++ b/docs/tips/editors-integration.md
@@ -3,6 +3,7 @@
 There are several extensions available to integrate `zk` in your favorite
 editor:
 
+- [`zk-emacs`](https://codeberg.org/mcookly/zk-emacs) for Emacs
 - [`zk-nvim`](https://github.com/zk-org/zk-nvim) for Neovim.
 - [`zk-vscode`](https://github.com/zk-org/zk-vscode) for Visual Studio Code
 


### PR DESCRIPTION
I've been working on an [Emacs package](https://codeberg.org/mcookly/zk-emacs) which integrates `zk` with Emacs over the past six months or so. Currently it's a stable "alpha" project, so I thought it best to weather it with other users.

I'm happy to provide further information as needed!
