### PR TITLE
Use AST to find links in LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Format: `<description> (by <contributor>, <pr number>)`
 
 ### Fixed
 
-...
+- Ignore commented links for LSP diagnostics. Use an AST to parse files, fixing
+  other similar edge cases. (by @WhyNotHugo, 638)
+
 
 ## 0.15.2
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -3,12 +3,16 @@ package lsp
 import (
 	"net/url"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"unicode/utf16"
 
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/zk-org/zk/internal/adapter/markdown/extensions"
 	"github.com/zk-org/zk/internal/core"
 	"github.com/zk-org/zk/internal/util"
 	"github.com/zk-org/zk/internal/util/errors"
@@ -64,10 +68,10 @@ func (s *documentStore) Get(pathOrURI string) (*document, bool) {
 	return d, ok
 }
 
-func (s *documentStore) normalizePath(pathOrUri string) (string, error) {
-	path, err := uriToPath(pathOrUri)
+func (s *documentStore) normalizePath(pathOrURI string) (string, error) {
+	path, err := uriToPath(pathOrURI)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to parse URI: %s", pathOrUri)
+		return "", errors.Wrapf(err, "unable to parse URI: %s", pathOrURI)
 	}
 	return s.fs.Canonical(path), nil
 }
@@ -82,7 +86,7 @@ type document struct {
 }
 
 // ApplyChanges updates the content of the document from LSP textDocument/didChange events.
-func (d *document) ApplyChanges(changes []interface{}) {
+func (d *document) ApplyChanges(changes []any) {
 	for _, change := range changes {
 		switch c := change.(type) {
 		case protocol.TextDocumentContentChangeEvent:
@@ -190,171 +194,115 @@ func (d *document) DocumentLinkAt(pos protocol.Position) (*documentLink, error) 
 	return nil, nil
 }
 
-// countUnescapedBackticks counts backticks that are not preceded by a backslash.
-func countUnescapedBackticks(s string) int {
-	count := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '`' && (i == 0 || s[i-1] != '\\') {
-			count++
+// documentParser is a goldmark parser configured for extracting links.
+var documentParser = goldmark.New(
+	goldmark.WithExtensions(
+		extensions.WikiLinkExt,
+		extensions.MarkdownLinkExt,
+	),
+)
+
+// byteOffsetToPosition converts a byte offset in source to a protocol.Position (line, character).
+// lineOffsets must contain the byte offset of the start of each line.
+func byteOffsetToPosition(offset int, source []byte, lineOffsets []int) protocol.Position {
+	line := 0
+	for i := 1; i < len(lineOffsets); i++ {
+		if lineOffsets[i] > offset {
+			break
 		}
+		line = i
 	}
-	return count
-}
+	lineStart := lineOffsets[line]
 
-// linkWithinInlineCode checks whether a link is within inline code.
-func linkWithinInlineCode(strBuffer string, linkStart, linkEnd int, insideInline bool) bool {
-	for i := 0; i < len(strBuffer) && i < linkEnd; i++ {
-		if strBuffer[i] == '`' && (i == 0 || strBuffer[i-1] != '\\') {
-			insideInline = !insideInline
-		}
-	}
-	return insideInline
-}
-
-var wikiLinkRegex = regexp.MustCompile(`\[?\[\[(.+?)(?: *\| *(.+?))?\]\]`)
-var markdownLinkRegex = regexp.MustCompile(`\[([^\]]+?[^\\])\]\((.+?[^\\])\)`)
-var fileURIregex = regexp.MustCompile(`file:///`)
-var fencedStartRegex = regexp.MustCompile(`^(` + "```" + `|~~~).*`)
-var fencedEndRegex = regexp.MustCompile(`^(` + "```" + `|~~~)\s*`)
-var indentedRegex = regexp.MustCompile(`^(\s{4}|\t).+`)
-var magnetRegex = regexp.MustCompile(`magnet:\?`)
-
-var insideInline = false
-var insideFenced = false
-var insideIndented = false
-var currentCodeBlockStart = -1
-
-// check whether the current line in document is within a fenced or indented
-// code block
-func isLineWithinCodeBlock(lines []string, lineIndex int, line string) bool {
-	// Reset global state from previous runs
-	if lineIndex == 0 {
-		insideInline = false
-		insideFenced = false
-		insideIndented = false
-		currentCodeBlockStart = -1
-	}
-
-	// if line is already within code fences or indented code block
-	if insideFenced {
-		if fencedEndRegex.FindStringIndex(line) != nil &&
-			lines[currentCodeBlockStart][:3] == line[:3] {
-			// Fenced code block ends with this line
-			insideFenced = false
-			currentCodeBlockStart = -1
-		}
-		return true
-	} else if insideIndented {
-		if indentedRegex.FindStringIndex(line) == nil && len(line) > 0 {
-			// Indeted code block ends with this line
-			insideIndented = false
-			currentCodeBlockStart = -1
-		} else {
-			return true
-		}
+	// Convert byte offset within line to rune index.
+	var lineContent string
+	if line+1 < len(lineOffsets) {
+		lineContent = string(source[lineStart : lineOffsets[line+1]-1]) // -1 to exclude newline.
 	} else {
-		// Check whether the current line is the start of a code fence or
-		// indented code block
-		if fencedStartRegex.FindStringIndex(line) != nil {
-			insideFenced = true
-			currentCodeBlockStart = lineIndex
-			return true
-		} else if indentedRegex.FindStringIndex(line) != nil &&
-			(lineIndex > 0 && len(lines[lineIndex-1]) == 0 || lineIndex == 0) {
-			insideIndented = true
-			currentCodeBlockStart = lineIndex
-			return true
+		lineContent = string(source[lineStart:]) // Last line.
+	}
+	byteOffsetInLine := offset - lineStart
+	charPos := strutil.ByteIndexToRuneIndex(lineContent, byteOffsetInLine)
+
+	return protocol.Position{
+		Line:      protocol.UInteger(line),
+		Character: protocol.UInteger(charPos),
+	}
+}
+
+// buildLineOffsets returns a slice where lineOffsets[i] is the byte offset of line i.
+func buildLineOffsets(source []byte) []int {
+	offsets := []int{0}
+	for i, b := range source {
+		if b == '\n' {
+			offsets = append(offsets, i+1)
 		}
 	}
-	return false
-
+	return offsets
 }
 
 // DocumentLinks returns all the internal and external links found in the
 // document.
 func (d *document) DocumentLinks() ([]documentLink, error) {
 	links := []documentLink{}
+	source := []byte(d.Content)
+	lineOffsets := buildLineOffsets(source)
 
-	lines := d.GetLines()
-	for lineIndex, line := range lines {
+	reader := text.NewReader(source)
+	context := parser.NewContext()
+	root := documentParser.Parser().Parse(reader, parser.WithContext(context))
 
-		if isLineWithinCodeBlock(lines, lineIndex, line) {
-			continue
+	ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
 		}
 
-		appendLink := func(href string, start, end int, hasTitle bool, isWikiLink bool) {
+		switch link := n.(type) {
+		case *extensions.MarkdownLink:
+			href := string(link.Destination)
 			if href == "" {
-				return
+				return ast.WalkContinue, nil
 			}
 
-			// Go regexes work with bytes, but the LSP client expects character indexes.
-			start = strutil.ByteIndexToRuneIndex(line, start)
-			end = strutil.ByteIndexToRuneIndex(line, end)
-
-			links = append(links, documentLink{
-				Href:          href,
-				RelativeToDir: filepath.Dir(d.Path),
-				Range: protocol.Range{
-					Start: protocol.Position{
-						Line:      protocol.UInteger(lineIndex),
-						Character: protocol.UInteger(start),
-					},
-					End: protocol.Position{
-						Line:      protocol.UInteger(lineIndex),
-						Character: protocol.UInteger(end),
-					},
-				},
-				HasTitle:   hasTitle,
-				IsWikiLink: isWikiLink,
-			})
-		}
-
-		// extract link paths from [title](path) patterns
-		// note: match[0:1] is the entire match, match[2:3] is the contents of
-		// brackets, match[4:5] is contents of parentheses
-		for _, match := range markdownLinkRegex.FindAllStringSubmatchIndex(line, -1) {
-			// Ignore when inside backticks: `[title](file)`
-			if linkWithinInlineCode(line, match[0], match[1], insideInline) {
-				continue
+			if strings.HasPrefix(href, "file:///") || strings.HasPrefix(href, "magnet:?") {
+				return ast.WalkContinue, nil
 			}
-
-			// Ignore embedded images ![title](file.png)
-			if match[0] > 0 && line[match[0]-1] == '!' {
-				continue
-			}
-
-			// ignore tripple dash file URIs [title](file:///foo.go) and magnet links
-			if match[5]-match[4] >= 8 {
-				linkURL := line[match[4]:match[5]]
-				fileURIresult := linkURL[:8]
-				if fileURIregex.MatchString(fileURIresult) || magnetRegex.MatchString(fileURIresult) {
-					continue
-				}
-			}
-
-			href := line[match[4]:match[5]]
 
 			// Decode the href if it's percent-encoded
 			if decodedHref, err := url.PathUnescape(href); err == nil {
 				href = decodedHref
 			}
 
-			appendLink(href, match[0], match[1], false, false)
+			links = append(links, documentLink{
+				Href:          href,
+				RelativeToDir: filepath.Dir(d.Path),
+				Range: protocol.Range{
+					Start: byteOffsetToPosition(link.StartOffset, source, lineOffsets),
+					End:   byteOffsetToPosition(link.EndOffset, source, lineOffsets),
+				},
+				IsWikiLink: false,
+			})
+
+		case *extensions.WikiLink:
+			href := string(link.Destination)
+			if href == "" {
+				return ast.WalkContinue, nil
+			}
+
+			links = append(links, documentLink{
+				Href:          href,
+				RelativeToDir: filepath.Dir(d.Path),
+				Range: protocol.Range{
+					Start: byteOffsetToPosition(link.StartOffset, source, lineOffsets),
+					End:   byteOffsetToPosition(link.EndOffset, source, lineOffsets),
+				},
+				HasTitle:   len(link.Title) > 0,
+				IsWikiLink: true,
+			})
 		}
 
-		for _, match := range wikiLinkRegex.FindAllStringSubmatchIndex(line, -1) {
-			// Ignore when inside backticks: `[[filename]]`
-			if linkWithinInlineCode(line, match[0], match[1], insideInline) {
-				continue
-			}
-			href := line[match[2]:match[3]]
-			hasTitle := match[4] != -1
-			appendLink(href, match[0], match[1], hasTitle, true)
-		}
-		if countUnescapedBackticks(line)%2 == 1 {
-			insideInline = !insideInline
-		}
-	}
+		return ast.WalkContinue, nil
+	})
 
 	return links, nil
 }

--- a/internal/adapter/lsp/document_test.go
+++ b/internal/adapter/lsp/document_test.go
@@ -81,45 +81,117 @@ func TestDocumentLinks_EscapedBackticks(t *testing.T) {
 	}
 }
 
-func TestLinkWithinInlineCode_EscapedBackticks(t *testing.T) {
+func TestDocumentLinks_HTMLComments(t *testing.T) {
 	tests := []struct {
-		name         string
-		line         string
-		linkStart    int
-		linkEnd      int
-		insideInline bool
-		expected     bool
+		name          string
+		content       string
+		expectedHrefs []string
 	}{
 		{
-			name:         "link after escaped backtick",
-			line:         "\\` [[link]]",
-			linkStart:    3,
-			linkEnd:      11,
-			insideInline: false,
-			expected:     false,
+			name:          "link inside HTML comment should be ignored",
+			content:       "<!-- [commented link](ignored.md) -->\n[[real-link]]",
+			expectedHrefs: []string{"real-link"},
 		},
 		{
-			name:         "link after real backtick",
-			line:         "` [[link]]",
-			linkStart:    2,
-			linkEnd:      10,
-			insideInline: false,
-			expected:     true,
+			name:          "wikilink inside HTML comment should be ignored",
+			content:       "<!-- [[commented-wiki]] -->\n[real](real.md)",
+			expectedHrefs: []string{"real.md"},
 		},
 		{
-			name:         "link after real inline code span",
-			line:         "`code` [[link]]",
-			linkStart:    7,
-			linkEnd:      15,
-			insideInline: false,
-			expected:     false,
+			name:          "link before and after HTML comment",
+			content:       "[[before]]\n<!-- [[ignored]] -->\n[[after]]",
+			expectedHrefs: []string{"before", "after"},
+		},
+		{
+			name:          "multiline HTML comment with link",
+			content:       "<!--\n[link](ignored.md)\n-->\n[[visible]]",
+			expectedHrefs: []string{"visible"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := linkWithinInlineCode(tt.line, tt.linkStart, tt.linkEnd, tt.insideInline)
-			assert.Equal(t, result, tt.expected)
+			doc := &document{
+				Content: tt.content,
+				Path:    "/test/note.md",
+			}
+			hrefs := extractHrefs(doc)
+			assert.Equal(t, hrefs, tt.expectedHrefs)
+		})
+	}
+}
+
+func TestDocumentLinks_CodeBlocks(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		expectedHrefs []string
+	}{
+		{
+			name:          "link inside fenced code block should be ignored",
+			content:       "```\n[[code-link]]\n```\n[[real-link]]",
+			expectedHrefs: []string{"real-link"},
+		},
+		{
+			name:          "link inside indented code block should be ignored",
+			content:       "Normal text\n\n    [[indented-code]]\n\n[[real-link]]",
+			expectedHrefs: []string{"real-link"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &document{
+				Content: tt.content,
+				Path:    "/test/note.md",
+			}
+			hrefs := extractHrefs(doc)
+			assert.Equal(t, hrefs, tt.expectedHrefs)
+		})
+	}
+}
+
+func TestDocumentLinks_ComplexContent(t *testing.T) {
+	tests := []struct {
+		name          string
+		content       string
+		expectedHrefs []string
+	}{
+		{
+			name:          "link with bold text",
+			content:       "[**bold link**](dest.md)",
+			expectedHrefs: []string{"dest.md"},
+		},
+		{
+			name:          "link with italic text",
+			content:       "[*italic link*](dest.md)",
+			expectedHrefs: []string{"dest.md"},
+		},
+		{
+			name:          "link with inline code",
+			content:       "[`code` link](dest.md)",
+			expectedHrefs: []string{"dest.md"},
+		},
+		{
+			name:          "link with parentheses in destination",
+			content:       "[link](path/with(parens).md)",
+			expectedHrefs: []string{"path/with(parens).md"},
+		},
+		{
+			name:          "multiple complex links",
+			content:       "[**bold**](one.md) and [*italic*](two.md)",
+			expectedHrefs: []string{"one.md", "two.md"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &document{
+				Content: tt.content,
+				Path:    "/test/note.md",
+			}
+			hrefs := extractHrefs(doc)
+			assert.Equal(t, hrefs, tt.expectedHrefs)
 		})
 	}
 }

--- a/internal/adapter/markdown/extensions/mdlink.go
+++ b/internal/adapter/markdown/extensions/mdlink.go
@@ -1,0 +1,124 @@
+package extensions
+
+import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// MarkdownLinkExt is parses markdown links and tracks their positions.
+//
+// ast.Link does not track position, and the LSP needs link positions.
+var MarkdownLinkExt = &markdownLinkExt{}
+
+type markdownLinkExt struct{}
+
+// MarkdownLink represents a markdown link with position tracking.
+type MarkdownLink struct {
+	ast.Link
+	Destination []byte
+	StartOffset int // Position of '['
+	EndOffset   int // Position after ')'
+}
+
+// KindMarkdownLink is the kind of MarkdownLink nodes.
+var KindMarkdownLink = ast.NewNodeKind("MarkdownLink")
+
+func (e *markdownLinkExt) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(
+		parser.WithInlineParsers(
+			// Higher priority than default link parser (100)
+			util.Prioritized(&mdLinkParser{}, 99),
+		),
+	)
+}
+
+type mdLinkParser struct{}
+
+func (p *mdLinkParser) Trigger() []byte {
+	return []byte{'['}
+}
+
+// Parse is called when a Trigger is found.
+func (p *mdLinkParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	line, segment := block.PeekLine()
+
+	// Skip images.
+	if segment.Start > 0 {
+		src := block.Source()
+		if segment.Start > 0 && src[segment.Start-1] == '!' {
+			return nil
+		}
+	}
+
+	// Find the closing ].
+	i := 1
+	depth := 1
+	for i < len(line) && depth > 0 {
+		switch line[i] {
+		case '\\':
+			i++ // Escaped char.
+		case '[':
+			depth++
+		case ']':
+			depth--
+		}
+		i++
+	}
+	// i now points after ].
+
+	if depth != 0 {
+		return nil // Unclosed [.
+	}
+
+	if i >= len(line) || line[i] != '(' {
+		return nil // Not an inline link
+	}
+
+	linkTextEnd := i - 1 // Position of ].
+	i++                  // Skip (.
+
+	// Parse destination until ')' with balanced parentheses.
+	destStart := i
+	parenDepth := 0
+	for i < len(line) {
+		c := line[i]
+		if c == '\\' && i+1 < len(line) {
+			i += 2
+			continue
+		}
+		if c == '(' {
+			parenDepth++
+		} else if c == ')' {
+			if parenDepth == 0 {
+				break
+			}
+			parenDepth--
+		}
+		i++
+	}
+
+	if i >= len(line) || line[i] != ')' {
+		return nil
+	}
+
+	destination := line[destStart:i]
+	i++ // Skip ).
+
+	link := &MarkdownLink{
+		Destination: destination,
+		StartOffset: segment.Start,
+		EndOffset:   segment.Start + i,
+	}
+
+	linkText := line[1:linkTextEnd]
+	if len(linkText) > 0 {
+		textNode := ast.NewTextSegment(text.NewSegment(segment.Start+1, segment.Start+1+len(linkText)))
+		link.AppendChild(link, textNode)
+	}
+
+	block.Advance(i)
+	return link
+}

--- a/internal/adapter/markdown/extensions/wikilink.go
+++ b/internal/adapter/markdown/extensions/wikilink.go
@@ -21,6 +21,10 @@ type wikiLink struct{}
 // WikiLink represents a wiki link found in a Markdown document.
 type WikiLink struct {
 	ast.Link
+	// StartOffset is the byte offset of the start of the link.
+	StartOffset int
+	// EndOffset is the byte offset of the end of the link.
+	EndOffset int
 }
 
 func (w *wikiLink) Extend(m goldmark.Markdown) {
@@ -38,7 +42,8 @@ func (p *wlParser) Trigger() []byte {
 }
 
 func (p *wlParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
-	line, _ := block.PeekLine()
+	line, segment := block.PeekLine()
+	startOffset := segment.Start
 
 	var (
 		href  string
@@ -145,6 +150,8 @@ func (p *wlParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) 
 	// Title will be parsed as the link's rel by the Markdown parser.
 	link.Title = []byte(rel)
 	link.AppendChild(link, ast.NewString([]byte(label)))
+	link.StartOffset = startOffset
+	link.EndOffset = startOffset + endPos
 
 	return link
 }


### PR DESCRIPTION
Commented links are recognised by the LSP as "real" links, despite them not being actual links on the document. Parsing by the LSP is done with its own bespoke logic, but we already have a perfectly working markdown parser which we use in non-LSP contexts.

Use the same markdown parser in the LSP, so we don't have to manually work around all the edge cases which it already handles. Ensure that the cli and LSP both provide consistent results.

This diff is best reviewed in side-by-side mode; many functions were replaced with new ones, and unified diff mode entangles both versions, yielding unreadable results.

Fixes: https://github.com/zk-org/zk/issues/630