### PR TITLE
Link weave

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Here you can read
 - [Neuron](https://github.com/srid/neuron) – a great tool to publish a
   Zettelkasten on the web
 - [Emanote](https://emanote.srid.ca/) – an improved successor to Neuron
+- [Weave](https://github.com/matze/weave) – another tool to publish Zettelkasten
+  on the web
 - [sirupsen's zk](https://github.com/sirupsen/zk) – a collection of scripts with
   a similar purpose
 - [zk-spaced](https://github.com/matze/zk-spaced) – spaced repetition plugin for

--- a/docs/tips/static-sites.md
+++ b/docs/tips/static-sites.md
@@ -7,6 +7,12 @@
 For an Emanote-specific zk configuration, see
 [https://emanote.srid.ca/start/resources/zk](https://emanote.srid.ca/start/resources/zk).
 
+## Weave
+
+[Weave](https://github.com/matze/weave) is a self-hosted zk-based viewer and
+editor for the web. For an example see the [demo
+page](https://weave.bloerg.net).
+
 ## Gollum
 
 [Gollum](https://github.com/gollum/gollum) is _"a simple, Git-powered wiki with


### PR DESCRIPTION
This adds links to my [weave](https://github.com/matze/weave) project to the README.md and the static site doc page even though it is actually dynamic.