### PR TITLE
Prevent out-of-bounds crashes of `textDocument/completion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Format: `<description> (by <contributor>, <pr number>)`
 - Links in markdown footnotes now included in :ZkLinks (by @WhyNotHugo, 639)
 - Indexing notebook now 35% and 74% faster for full and incremental indexing
   respectively (by @WhyNotHugo, 642)
-- Stop crashing lsp server when server received `textDocument/completion` request with out of range parameters. (by @virusbb001, XXX)
+- Stop crashing lsp server when server received `textDocument/completion` request with out of range parameters. (by @virusbb001, 667)
 
 ## 0.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Format: `<description> (by <contributor>, <pr number>)`
 - Links in markdown footnotes now included in :ZkLinks (by @WhyNotHugo, 639)
 - Indexing notebook now 35% and 74% faster for full and incremental indexing
   respectively (by @WhyNotHugo, 642)
-
+- Stop crashing lsp server when server received `textDocument/completion` request with out of range parameters. (by @virusbb001, XXX)
 
 ## 0.15.2
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -322,7 +322,8 @@ func (d *document) IsTagPosition(position protocol.Position, noteContentParser c
 		return false
 	}
 	line := lines[lineIdx]
-	if len(line) < charIdx {
+	utf16Len := len(utf16.Encode([]rune(line)))
+	if utf16Len < charIdx {
 		return false
 	}
 	// https://github.com/zk-org/zk/issues/144#issuecomment-1006108485

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -318,7 +318,13 @@ func (d *document) IsTagPosition(position protocol.Position, noteContentParser c
 	lines := strutil.CopyList(d.GetLines())
 	lineIdx := int(position.Line)
 	charIdx := int(position.Character)
+	if len(lines) <= lineIdx {
+		return false
+	}
 	line := lines[lineIdx]
+	if len(line) <= charIdx {
+		return false
+	}
 	// https://github.com/zk-org/zk/issues/144#issuecomment-1006108485
 	line = line[:charIdx] + "ZK_PLACEHOLDER" + line[charIdx:]
 	lines[lineIdx] = line

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -322,7 +322,7 @@ func (d *document) IsTagPosition(position protocol.Position, noteContentParser c
 		return false
 	}
 	line := lines[lineIdx]
-	if len(line) <= charIdx {
+	if len(line) < charIdx {
 		return false
 	}
 	// https://github.com/zk-org/zk/issues/144#issuecomment-1006108485

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -137,12 +137,16 @@ func (d *document) GetLines() []string {
 // LookBehind returns the n characters before the given position, on the same line.
 func (d *document) LookBehind(pos protocol.Position, length int) string {
 	line, ok := d.GetLine(int(pos.Line))
-	utf16Bytes := utf16.Encode([]rune(line))
 	if !ok {
 		return ""
 	}
+	utf16Bytes := utf16.Encode([]rune(line))
 
 	charIdx := int(pos.Character)
+	if charIdx > len(utf16Bytes) {
+		charIdx = len(utf16Bytes)
+	}
+
 	if length > charIdx {
 		return string(utf16.Decode(utf16Bytes[0:charIdx]))
 	}

--- a/internal/adapter/lsp/document_test.go
+++ b/internal/adapter/lsp/document_test.go
@@ -1,9 +1,11 @@
 package lsp
 
 import (
+	"regexp"
 	"testing"
 
 	protocol "github.com/tliron/glsp/protocol_3_16"
+	"github.com/zk-org/zk/internal/core"
 	"github.com/zk-org/zk/internal/util/test/assert"
 )
 
@@ -311,6 +313,105 @@ func TestDocument_LookBehind(t *testing.T) {
 				Path:    "/test/note.md",
 			}
 			actual := doc.LookBehind(tt.pos, tt.length)
+			assert.Equal(t, actual, tt.expected)
+		})
+	}
+}
+
+type mockNoteContentParser struct{}
+
+func (m *mockNoteContentParser) ParseNoteContent(content string) (*core.NoteContent, error) {
+	tags := []string{}
+	// This mock parser only finds hashtags.
+	// It's important to match the behavior where ZK_PLACEHOLDER is part of the tag.
+	re := regexp.MustCompile(`#[^ \t\n\f\r,;\[\]\"\']+`)
+	matches := re.FindAllString(content, -1)
+	for _, match := range matches {
+		tags = append(tags, match[1:]) // strip #
+	}
+	return &core.NoteContent{Tags: tags}, nil
+}
+
+func TestDocument_IsTagPosition(t *testing.T) {
+	parser := &mockNoteContentParser{}
+	tests := []struct {
+		name     string
+		content  string
+		pos      protocol.Position
+		expected bool
+	}{
+		{
+			name:    "at the start of a hashtag (#)",
+			content: "hello #tag world",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 6, // at #
+			},
+			expected: false, // ZK_PLACEHOLDER is inserted BEFORE #, so it's "ZK_PLACEHOLDER#tag" which is not a tag
+		},
+		{
+			name:    "just after #",
+			content: "hello #tag world",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 7, // after #
+			},
+			expected: true,
+		},
+		{
+			name:    "inside a hashtag",
+			content: "hello #tag world",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 8, // at a
+			},
+			expected: true,
+		},
+		{
+			name:    "at the end of a hashtag",
+			content: "hello #tag world",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 10, // after g
+			},
+			expected: true,
+		},
+		{
+			name:    "not in a tag (at 'h')",
+			content: "hello #tag world",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 0, // at h
+			},
+			expected: false,
+		},
+		{
+			name:    "between two tags (at space)",
+			content: "#tag1 #tag2",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 5, // space between
+			},
+			expected: true, // WordAt returns "#tag1" at index 5
+		},
+		{
+			name:    "in multiple lines",
+			content: "line1\n#tag line2",
+			pos: protocol.Position{
+				Line:      1,
+				Character: 2, // at 't' in #tag
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &document{
+				Content: tt.content,
+				Path:    "/test/note.md",
+			}
+			actual := doc.IsTagPosition(tt.pos, parser)
 			assert.Equal(t, actual, tt.expected)
 		})
 	}

--- a/internal/adapter/lsp/document_test.go
+++ b/internal/adapter/lsp/document_test.go
@@ -421,6 +421,15 @@ func TestDocument_IsTagPosition(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name:    "at end of line (true for completion)",
+			content: "#zk",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 3,
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapter/lsp/document_test.go
+++ b/internal/adapter/lsp/document_test.go
@@ -430,6 +430,24 @@ func TestDocument_IsTagPosition(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name:    "utf-16 test",
+			content: "#雨果",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 2,
+			},
+			expected: true,
+		},
+		{
+			name:    "utf-16 test out of bounds",
+			content: "#雨果",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 4,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapter/lsp/document_test.go
+++ b/internal/adapter/lsp/document_test.go
@@ -403,6 +403,24 @@ func TestDocument_IsTagPosition(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name:    "out of bound line",
+			content: "line1\n#tag line2",
+			pos: protocol.Position{
+				Line:      10,
+				Character: 2,
+			},
+			expected: false,
+		},
+		{
+			name:    "out of bound character",
+			content: "line1\n#tag line2",
+			pos: protocol.Position{
+				Line:      1,
+				Character: 100,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/adapter/lsp/document_test.go
+++ b/internal/adapter/lsp/document_test.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"testing"
 
+	protocol "github.com/tliron/glsp/protocol_3_16"
 	"github.com/zk-org/zk/internal/util/test/assert"
 )
 
@@ -244,6 +245,73 @@ func TestDocumentLinks_ComplexContent(t *testing.T) {
 			}
 			hrefs := extractHrefs(doc)
 			assert.Equal(t, hrefs, tt.expectedHrefs)
+		})
+	}
+}
+
+func TestDocument_LookBehind(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		pos      protocol.Position
+		length   int
+		expected string
+	}{
+		{
+			name:    "empty",
+			content: "",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 0,
+			},
+			length:   0,
+			expected: "",
+		},
+		{
+			name:     "normal case",
+			content:  "hello world",
+			pos:      protocol.Position{Line: 0, Character: 5},
+			length:   2,
+			expected: "lo",
+		},
+		{
+			name:     "normal case",
+			content:  "hello world",
+			pos:      protocol.Position{Line: 0, Character: 5},
+			length:   2,
+			expected: "lo",
+		},
+		{
+			name:     "out of bound line index",
+			content:  "lorem\nipsum\ndor\nsit\n",
+			pos:      protocol.Position{Line: 6, Character: 0},
+			length:   0,
+			expected: "",
+		},
+		{
+			name:     "out of bound length",
+			content:  "hello world",
+			pos:      protocol.Position{Line: 0, Character: 5},
+			length:   10,
+			expected: "hello",
+		},
+		{
+			name:     "out of bound character",
+			content:  "#abc #z",
+			pos:      protocol.Position{Line: 0, Character: 8},
+			length:   8,
+			expected: "#abc #z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &document{
+				Content: tt.content,
+				Path:    "/test/note.md",
+			}
+			actual := doc.LookBehind(tt.pos, tt.length)
+			assert.Equal(t, actual, tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
## Description

The `zk` LSP server panics and crashes when receiving a `textDocument/completion` request with a `position.character` that exceeds the current line's length.

## Panic Log

```text
panic: runtime error: slice bounds out of range [:8] with capacity 7

goroutine 13 [running]:
github.com/zk-org/zk/internal/adapter/lsp.(*document).LookBehind(0x8d3a25?, {0x708120?, 0xc0?}, 0x2)
        github.com/zk-org/zk/internal/adapter/lsp/document.go:144 +0x165
github.com/zk-org/zk/internal/adapter/lsp.(*Server).buildInvokedCompletionList(0xc000116600, 0xc0001a7d40, 0xc0004ed590, {0x2c8e10?, 0xc0?})
        github.com/zk-org/zk/internal/adapter/lsp/server.go:647 +0x4b
...
```

## Reproduction Context

1. Run `zk lsp`.
1. Send `initialize` request and wait response.
    * rootUri is `file:///path/to/notebooks/`
1. Send `initialized` notification.
1. Send `textDocument/didOpen` notification.
    * `{"textDocument": {"version": 0, "text": "# Zk\n\n#abc #z\n", "languageId": "markdown", "uri": "file:///path/to/notebooks/Zk.md"}}`
1. Wait `textDocument/publishDiagnostics` notification.
1. Send `textDocument/completion` request.
    * `{"position": {"character": 8, "line": 2}, "context": {"triggerKind": 1}, "textDocument": {"uri": "file:///path/to/notebooks/Zk.md"}}`
1. LSP Server caused panic.

I think this is a client bug (textDocument/completion should be called after sending textDocument/didChange notification). However, I want to avoid causing panic even the LSP client sends an invalid request. 
