### PR TITLE
Prevent crash in LookForward when the parameters is out of characters number.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Format: `<description> (by <contributor>, <pr number>)`
   respectively (by @WhyNotHugo, 642)
 - Stop crashing lsp server when server received `textDocument/completion` request with out of range parameters. (by @virusbb001, 667)
 - lsp: Provide completion after [[ on lines with multi-byte characters (by @virusbb001, 671)
-- Prevent crush in LookForward when the parameters is out of characters number. (by @virusbb001, 673)
+- Prevent crash in LookForward when the parameters is out of characters number. (by @virusbb001, 673)
 
 ## 0.15.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format: `<description> (by <contributor>, <pr number>)`
   respectively (by @WhyNotHugo, 642)
 - Stop crashing lsp server when server received `textDocument/completion` request with out of range parameters. (by @virusbb001, 667)
 - lsp: Provide completion after [[ on lines with multi-byte characters (by @virusbb001, 671)
+- Prevent crush in LookForward when the parameters is out of characters number. (by @virusbb001, 673)
 
 ## 0.15.2
 

--- a/internal/adapter/lsp/document.go
+++ b/internal/adapter/lsp/document.go
@@ -164,7 +164,7 @@ func (d *document) LookForward(pos protocol.Position, length int) string {
 	}
 
 	lineLength := len(utf16Bytes)
-	charIdx := int(pos.Character)
+	charIdx := min(int(pos.Character), len(utf16Bytes))
 	if lineLength <= charIdx+length {
 		return string(utf16.Decode(utf16Bytes[charIdx:]))
 	}

--- a/internal/adapter/lsp/document_test.go
+++ b/internal/adapter/lsp/document_test.go
@@ -323,6 +323,66 @@ func TestDocument_LookBehind(t *testing.T) {
 	}
 }
 
+func TestDocument_LookForward(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		pos      protocol.Position
+		length   int
+		expected string
+	}{
+		{
+			name:    "empty",
+			content: "",
+			pos: protocol.Position{
+				Line:      0,
+				Character: 0,
+			},
+			length:   0,
+			expected: "",
+		},
+		{
+			name:     "normal case",
+			content:  "hello world",
+			pos:      protocol.Position{Line: 0, Character: 5},
+			length:   2,
+			expected: " w",
+		},
+		{
+			name:     "out of bound line index",
+			content:  "lorem\nipsum\ndor\nsit\n",
+			pos:      protocol.Position{Line: 6, Character: 0},
+			length:   0,
+			expected: "",
+		},
+		{
+			name:     "out of bound length",
+			content:  "hello world",
+			pos:      protocol.Position{Line: 0, Character: 5},
+			length:   10,
+			expected: " world",
+		},
+		{
+			name:     "out of bound character",
+			content:  "#abc #z",
+			pos:      protocol.Position{Line: 0, Character: 100},
+			length:   8,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &document{
+				Content: tt.content,
+				Path:    "/test/note.md",
+			}
+			actual := doc.LookForward(tt.pos, tt.length)
+			assert.Equal(t, actual, tt.expected)
+		})
+	}
+}
+
 type mockNoteContentParser struct{}
 
 func (m *mockNoteContentParser) ParseNoteContent(content string) (*core.NoteContent, error) {


### PR DESCRIPTION
Mostly similar to #667

## Reproduction Step

Mostly the same as #667, but the content of the file and parameters are different.

The content of the file (passed in `textDocument/didOpen` ) is

```markdown
日本語 [[It
```

and the parameter is
```json
{
  "position": {
    "character": 14,
    "line": 0
  },
  "textDocument": {
    "uri": "file:///path/to/file.md"
  },
  "context": {
    "triggerKind": 1
  }
}
```

