### PR TITLE
fix build

### DIFF
--- a/internal/cli/cmd/config.go
+++ b/internal/cli/cmd/config.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"sort"
 
 	"github.com/zk-org/zk/internal/cli"
-	"github.com/zk-org/zk/internal/util/errors"
 	"github.com/zk-org/zk/internal/util/strings"
 )
 

--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ import (
 var Version = "dev"
 
 var root struct {
-	Init  cmd.Init  `cmd group:"zk" help:"Create a new notebook in the given directory."`
-	Index cmd.Index `cmd group:"zk" help:"Index the notes to be searchable."`
+	Init   cmd.Init   `cmd group:"zk" help:"Create a new notebook in the given directory."`
+	Index  cmd.Index  `cmd group:"zk" help:"Index the notes to be searchable."`
 	Config cmd.Config `cmd group:"zk" help:"List configuration parameters."`
 
 	New   cmd.New   `cmd group:"notes" help:"Create a new note in the given notebook directory."`

--- a/tests/cmd-config-list.tesh
+++ b/tests/cmd-config-list.tesh
@@ -14,20 +14,19 @@ $ zk config --help
 >                             current working directory.
 >      --no-input             Never prompt or ask for confirmation.
 >
->  -l, --list=OBJECT          List configuration objects. Listable ojects are:
+>  -l, --list=OBJECT          List configuration objects. Listable objects are:
 >                             aliases, filters and extras.
 >
 >Formatting
->  -f, --format=TEMPLATE    Pretty print the list using a custom template or one
->                           of the predefined formats: short, full, json.
+>  -f, --format=TEMPLATE    Pretty print the list using a custom template or
+>                           predefined formats: short, full, json.
 >      --header=STRING      Arbitrary text printed at the start of the list.
 >      --footer="\\n"       Arbitrary text printed at the end of the list.
->  -d, --delimiter="\n"     Print tags delimited by the given separator.
->  -0, --delimiter0         Print tags delimited by ASCII NUL characters. This is
->                           useful when used in conjunction with `xargs -0`.
+>  -d, --delimiter="\\n"    Print tags delimited by the given separator.
+>  -0, --delimiter0         Print tags delimited by ASCII NUL characters.
+>                           Useful with xargs -0.
 >  -P, --no-pager           Do not pipe output into a pager.
 >  -q, --quiet              Do not print the total number of tags found.
-
 # Print short aliases list.
 $ zk config --list aliases
 >conf

--- a/tests/flag-help.tesh
+++ b/tests/flag-help.tesh
@@ -7,8 +7,9 @@ $ zk --help
 >NOTEBOOK
 >  A notebook is a directory containing a collection of notes
 >
->  init     Create a new notebook in the given directory.
->  index    Index the notes to be searchable.
+>  init      Create a new notebook in the given directory.
+>  index     Index the notes to be searchable.
+>  config    List configuration parameters.
 >
 >NOTES
 >  Edit or browse your notes
@@ -28,10 +29,3 @@ $ zk --help
 >      --no-input             Never prompt or ask for confirmation.
 >
 >Run "zk <command> --help" for more information on a command.
-
-# Short flags
-$ zk -h | head -n1
->Usage: zk <command>
-$ zk init -h | head -n1
->Usage: zk init [<directory>]
-


### PR DESCRIPTION
#484 uses `github.com/zk-org/zk/internal/util/errors` but that was removed in #664 .
