### PR TITLE
Pass shell explicitly to functions that need it

### DIFF
--- a/internal/adapter/editor/editor.go
+++ b/internal/adapter/editor/editor.go
@@ -15,11 +15,12 @@ import (
 // Editor represents an external editor able to edit the notes.
 type Editor struct {
 	editor string
+	shell  string
 }
 
 // NewEditor creates a new Editor from the given editor user setting or the
 // matching environment variables.
-func NewEditor(editor opt.String) (*Editor, error) {
+func NewEditor(editor opt.String, shell string) (*Editor, error) {
 	editor = osutil.GetOptEnv("ZK_EDITOR").
 		Or(editor).
 		Or(osutil.GetOptEnv("VISUAL")).
@@ -29,7 +30,7 @@ func NewEditor(editor opt.String) (*Editor, error) {
 		return nil, fmt.Errorf("no editor set in config")
 	}
 
-	return &Editor{editor.Unwrap()}, nil
+	return &Editor{editor: editor.Unwrap(), shell: shell}, nil
 }
 
 // Open launches the editor with the notes at given paths.
@@ -38,7 +39,7 @@ func (e *Editor) Open(paths ...string) error {
 	// initial note content to `zk new`. Without this, Vim doesn't work
 	// properly in this case.
 	// See https://github.com/zk-org/zk/issues/4
-	cmd := executil.CommandFromString(e.editor + " " + shellquote.Join(paths...) + CMD_SUFFIX)
+	cmd := executil.CommandFromString(e.shell, e.editor+" "+shellquote.Join(paths...)+CMD_SUFFIX)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/adapter/editor/editor_test.go
+++ b/internal/adapter/editor/editor_test.go
@@ -13,7 +13,7 @@ func TestEditorUsesZkEditorFirst(t *testing.T) {
 	os.Setenv("VISUAL", "visual")
 	os.Setenv("EDITOR", "editor")
 
-	editor, err := NewEditor(opt.NewString("custom-editor"))
+	editor, err := NewEditor(opt.NewString("custom-editor"), "/bin/sh")
 	assert.Nil(t, err)
 	assert.Equal(t, editor.editor, "zk-editor")
 }
@@ -23,7 +23,7 @@ func TestEditorFallsbackOnUserConfig(t *testing.T) {
 	os.Setenv("VISUAL", "visual")
 	os.Setenv("EDITOR", "editor")
 
-	editor, err := NewEditor(opt.NewString("custom-editor"))
+	editor, err := NewEditor(opt.NewString("custom-editor"), "/bin/sh")
 	assert.Nil(t, err)
 	assert.Equal(t, editor.editor, "custom-editor")
 }
@@ -33,7 +33,7 @@ func TestEditorFallsbackOnVisual(t *testing.T) {
 	os.Setenv("VISUAL", "visual")
 	os.Setenv("EDITOR", "editor")
 
-	editor, err := NewEditor(opt.NullString)
+	editor, err := NewEditor(opt.NullString, "/bin/sh")
 	assert.Nil(t, err)
 	assert.Equal(t, editor.editor, "visual")
 }
@@ -43,7 +43,7 @@ func TestEditorFallsbackOnEditor(t *testing.T) {
 	os.Unsetenv("VISUAL")
 	os.Setenv("EDITOR", "editor")
 
-	editor, err := NewEditor(opt.NullString)
+	editor, err := NewEditor(opt.NullString, "/bin/sh")
 	assert.Nil(t, err)
 	assert.Equal(t, editor.editor, "editor")
 }
@@ -53,7 +53,7 @@ func TestEditorFailsWhenUnset(t *testing.T) {
 	os.Unsetenv("VISUAL")
 	os.Unsetenv("EDITOR")
 
-	editor, err := NewEditor(opt.NullString)
+	editor, err := NewEditor(opt.NullString, "/bin/sh")
 	assert.Err(t, err, "no editor set in config")
 	assert.Nil(t, editor)
 }

--- a/internal/adapter/handlebars/handlebars.go
+++ b/internal/adapter/handlebars/handlebars.go
@@ -20,7 +20,6 @@ func Init(supportsUTF8 bool, logger util.Logger) {
 	helpers.RegisterJSON(logger)
 	helpers.RegisterList(supportsUTF8)
 	helpers.RegisterPrepend(logger)
-	helpers.RegisterShell(logger)
 	helpers.RegisterSubstring()
 }
 

--- a/internal/adapter/handlebars/handlebars_test.go
+++ b/internal/adapter/handlebars/handlebars_test.go
@@ -394,6 +394,7 @@ func testLoader(opts LoaderOpts) *Loader {
 
 	loader.RegisterHelper("style", helpers.NewStyleHelper(opts.Styler, &util.NullLogger))
 	loader.RegisterHelper("slug", helpers.NewSlugHelper("en", &util.NullLogger))
+	loader.RegisterHelper("sh", helpers.NewShellHelper(&util.NullLogger, "sh"))
 
 	formatter := func(context core.LinkFormatterContext) (string, error) {
 		return context.Path + " - " + context.Title, nil

--- a/internal/adapter/handlebars/helpers/shell.go
+++ b/internal/adapter/handlebars/helpers/shell.go
@@ -8,13 +8,14 @@ import (
 	"github.com/zk-org/zk/internal/util/exec"
 )
 
-// RegisterShell registers the {{sh}} template helper, which runs shell commands.
+// NewShellHelper returns a {{sh}} template helper function that runs shell commands.
+// The shellProvider function is called to determine which shell to use.
 //
 // {{#sh "tr '[a-z]' '[A-Z]'"}}Hello, world!{{/sh}} -> HELLO, WORLD!
 // {{sh "echo 'Hello, world!'"}} -> Hello, world!
-func RegisterShell(logger util.Logger) {
-	raymond.RegisterHelper("sh", func(arg string, options *raymond.Options) string {
-		cmd := exec.CommandFromString(arg)
+func NewShellHelper(logger util.Logger, shell string) interface{} {
+	return func(arg string, options *raymond.Options) string {
+		cmd := exec.CommandFromString(shell, arg)
 
 		// Feed any block content as piped input
 		cmd.Stdin = strings.NewReader(options.Fn())
@@ -26,5 +27,5 @@ func RegisterShell(logger util.Logger) {
 		}
 
 		return strings.TrimSpace(string(output))
-	})
+	}
 }

--- a/internal/cli/container.go
+++ b/internal/cli/container.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zk-org/zk/internal/adapter/term"
 	"github.com/zk-org/zk/internal/core"
 	"github.com/zk-org/zk/internal/util"
+	executil "github.com/zk-org/zk/internal/util/exec"
 	osutil "github.com/zk-org/zk/internal/util/os"
 	"github.com/zk-org/zk/internal/util/pager"
 	"github.com/zk-org/zk/internal/util/paths"
@@ -83,10 +84,9 @@ func NewContainer(version string) (*Container, error) {
 		os.Setenv("ZK_NOTEBOOK_DIR", notebookDir)
 	}
 
-	// Set the default shell if not already set
-	if osutil.GetOptEnv("ZK_SHELL").IsNull() && !config.Tool.Shell.IsEmpty() {
-		os.Setenv("ZK_SHELL", config.Tool.Shell.Unwrap())
-	}
+	// Register the shell helper with the resolved shell.
+	shell := executil.ResolveShell(config.Tool.Shell)
+	templateLoader.RegisterHelper("sh", hbhelpers.NewShellHelper(logger, shell))
 
 	return &Container{
 		Version:        version,
@@ -127,6 +127,7 @@ func NewContainer(version string) (*Container, error) {
 
 						loader.RegisterHelper("style", hbhelpers.NewStyleHelper(styler, logger))
 						loader.RegisterHelper("slug", hbhelpers.NewSlugHelper(language, logger))
+						loader.RegisterHelper("sh", hbhelpers.NewShellHelper(logger, executil.ResolveShell(config.Tool.Shell)))
 
 						linkFormatter, err := core.NewLinkFormatter(config.Format.Markdown, loader)
 						if err != nil {
@@ -236,7 +237,8 @@ func (c *Container) NewNoteFilter(opts fzf.NoteFilterOpts) *fzf.NoteFilter {
 }
 
 func (c *Container) NewNoteEditor(notebook *core.Notebook) (*editor.Editor, error) {
-	return editor.NewEditor(notebook.Config.Tool.Editor)
+	shell := executil.ResolveShell(notebook.Config.Tool.Shell)
+	return editor.NewEditor(notebook.Config.Tool.Editor, shell)
 }
 
 // Paginate creates an auto-closing io.Writer which will be automatically
@@ -257,6 +259,7 @@ func (c *Container) pager(noPager bool) (*pager.Pager, error) {
 	if noPager || !c.Terminal.IsInteractive() {
 		return pager.PassthroughPager, nil
 	} else {
-		return pager.New(c.Config.Tool.Pager, c.Logger)
+		shell := executil.ResolveShell(c.Config.Tool.Shell)
+		return pager.New(c.Config.Tool.Pager, shell, c.Logger)
 	}
 }

--- a/internal/util/exec/exec_unix.go
+++ b/internal/util/exec/exec_unix.go
@@ -5,16 +5,22 @@ package exec
 import (
 	"os/exec"
 
+	"github.com/zk-org/zk/internal/util/opt"
 	osutil "github.com/zk-org/zk/internal/util/os"
 )
 
-// CommandFromString returns a Cmd running the given command with $SHELL.
-func CommandFromString(command string, args ...string) *exec.Cmd {
-	shell := osutil.GetOptEnv("ZK_SHELL").
+// ResolveShell returns the shell to use for running commands, checking in order:
+// ZK_SHELL environment variable, config/tool.shell, SHELL environment variable, or "sh" as fallback.
+func ResolveShell(configShell opt.String) string {
+	return osutil.GetOptEnv("ZK_SHELL").
+		Or(configShell).
 		Or(osutil.GetOptEnv("SHELL")).
 		OrString("sh").
 		Unwrap()
+}
 
+// CommandFromString returns a Cmd running the given command with the specified shell.
+func CommandFromString(shell, command string, args ...string) *exec.Cmd {
 	args = append([]string{"-c", command, "--"}, args...)
 	return exec.Command(shell, args...)
 }

--- a/internal/util/exec/exec_windows.go
+++ b/internal/util/exec/exec_windows.go
@@ -5,10 +5,19 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+
+	"github.com/zk-org/zk/internal/util/opt"
 )
 
+// ResolveShell returns the shell to use. On Windows, this always returns "cmd"
+// as the shell configuration is not applicable.
+func ResolveShell(configShell opt.String) string {
+	return "cmd"
+}
+
 // CommandFromString returns a Cmd running the given command.
-func CommandFromString(command string, args ...string) *exec.Cmd {
+// The shell parameter is ignored on Windows as it uses cmd directly.
+func CommandFromString(shell, command string, args ...string) *exec.Cmd {
 	cmd := exec.Command("cmd")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    false,

--- a/internal/util/pager/pager.go
+++ b/internal/util/pager/pager.go
@@ -31,13 +31,13 @@ var PassthroughPager = &Pager{
 }
 
 // New creates a pager.Pager to be used to write a paginated text to the terminal.
-func New(pagerCmd opt.String, logger util.Logger) (*Pager, error) {
+func New(pagerCmd opt.String, shell string, logger util.Logger) (*Pager, error) {
 	pagerCmd = selectPagerCmd(pagerCmd)
 	if pagerCmd.IsNull() {
 		return PassthroughPager, nil
 	}
 
-	cmd := executil.CommandFromString(pagerCmd.String())
+	cmd := executil.CommandFromString(shell, pagerCmd.String())
 
 	r, w, err := os.Pipe()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -181,7 +181,8 @@ func runAlias(container *cli.Container, args []string) (bool, error) {
 			cmdStr = `cd "` + notebook.Path + `" && ` + cmdStr
 		}
 
-		cmd := executil.CommandFromString(cmdStr, args[1:]...)
+		shell := executil.ResolveShell(container.Config.Tool.Shell)
+		cmd := executil.CommandFromString(shell, cmdStr, args[1:]...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
The shell specified in the configuration is passed internally by setting the ZK_SHELL environment variable in one place, and then assuming it is set in functions that need it.

This makes reasoning about ordering nearly impossible, since there's no variable being passed, but a global variable being set instead.

Pass the shell explicitly to sites that need to use it.

Fixes: https://github.com/zk-org/zk/issues/689
