### PR TITLE
Fix inverted condition

### DIFF
--- a/internal/adapter/sqlite/note_index.go
+++ b/internal/adapter/sqlite/note_index.go
@@ -193,7 +193,7 @@ func (ni *NoteIndex) linkMatchesPath(link core.ResolvedLink, path string) (bool,
 	}
 
 	baseDir := filepath.Join(ni.notebookPath, filepath.Dir(link.SourcePath))
-	if relHref, err := ni.relNotebookPath(baseDir, href); err != nil {
+	if relHref, err := ni.relNotebookPath(baseDir, href); err == nil {
 		if matches(relHref, false) {
 			return true, nil
 		}


### PR DESCRIPTION
linkMatchesPath validates that `err != nil` and then uses the non-error value.

Invert this condition; only use the value if there **was not** an error.