### PR TITLE
Skip </dev/tty redirect when stdin is already a terminal

### DIFF
--- a/internal/adapter/editor/editor.go
+++ b/internal/adapter/editor/editor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kballard/go-shellquote"
+	"github.com/mattn/go-isatty"
 	executil "github.com/zk-org/zk/internal/util/exec"
 	"github.com/zk-org/zk/internal/util/opt"
 	osutil "github.com/zk-org/zk/internal/util/os"
@@ -35,11 +36,18 @@ func NewEditor(editor opt.String, shell string) (*Editor, error) {
 
 // Open launches the editor with the notes at given paths.
 func (e *Editor) Open(paths ...string) error {
-	// /dev/tty is restored as stdin, in case the user used a pipe to feed
-	// initial note content to `zk new`. Without this, Vim doesn't work
-	// properly in this case.
-	// See https://github.com/zk-org/zk/issues/4
-	cmd := executil.CommandFromString(e.shell, e.editor+" "+shellquote.Join(paths...)+CMD_SUFFIX)
+	// If stdin is a pipe, pipe it to the editor, so it can consume the output from
+	// that pipe. Allows providing input to commands like `zk new` when using Vim.
+	//
+	// Don't redirect a tty, since that messes up rendering of some TUI editors.
+	//
+	// See: https://github.com/zk-org/zk/issues/4
+	// See: https://github.com/zk-org/zk/pull/693
+	suffix := CMD_SUFFIX
+	if isatty.IsTerminal(os.Stdin.Fd()) {
+		suffix = ""
+	}
+	cmd := executil.CommandFromString(e.shell, e.editor+" "+shellquote.Join(paths...)+suffix)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
The </dev/tty redirect was unconditionally appended to the editor command to fix vim when stdin is a pipe (see #4). However, this breaks TUI editors that use crossterm for terminal I/O (e.g. fresh) — the redirected fd causes a blank screen.

Only apply the redirect when stdin is actually a pipe, which is the only case where it is needed.

...

fixes #692
